### PR TITLE
tiny-deseq has been improved

### DIFF
--- a/tiny/cwl/tools/tiny-deseq.cwl
+++ b/tiny/cwl/tools/tiny-deseq.cwl
@@ -38,4 +38,4 @@ outputs:
   pca_plots:
     type: File[]?
     outputBinding:
-      glob: $(inputs.outfile_prefix)_*_*_pca_plot.pdf
+      glob: $(inputs.outfile_prefix)_pca_plot.pdf

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -298,24 +298,6 @@ def scatter_samples(count_df, output_prefix, classes=None, dges=None, show_unkno
             sscat.figure.savefig(pdf_name, bbox_inches='tight')
 
 
-def get_r_safename(name: str) -> str:
-    """Converts a string to a syntactically valid R name
-
-    This is used on tables which haven't been produced by R (ex: raw_counts),
-    so that column headers match the column headers of those that have (ex: norm_counts).
-    https://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html
-
-    Args:
-        name: The string to be sanitized
-    Returns:
-        The sanitized string
-    """
-
-    leading_char = lambda x: re.sub(r"^(?=[^a-zA-Z.]+|\.\d)", "X", x)
-    special_char = lambda x: re.sub(r"[^a-zA-Z0-9_.]", ".", x)
-    return special_char(leading_char(name))
-
-
 def load_raw_counts(raw_counts_file: str) -> Optional[pd.DataFrame]:
     """Loads a raw_counts CSV as a DataFrame and sanitizes its column headers
     Args:
@@ -326,7 +308,6 @@ def load_raw_counts(raw_counts_file: str) -> Optional[pd.DataFrame]:
 
     if raw_counts_file is None: return None
     raw_count_df = pd.read_csv(raw_counts_file, index_col=0)
-    raw_count_df.rename(get_r_safename, axis="columns", inplace=True)
 
     return raw_count_df
 

--- a/tiny/rna/tiny-deseq.r
+++ b/tiny/rna/tiny-deseq.r
@@ -115,7 +115,6 @@ if (plot_pca){
     plt <- plotPCA(DESeq2::rlog(deseq_ds))
     trellis.device(device="pdf", file=paste(out_pref, "pca_plot.pdf", sep="_"))
     print(plt)
-    dev.off()
 }
 
 ## Get normalized counts and write them to CSV with original sample names in header

--- a/tiny/rna/util.py
+++ b/tiny/rna/util.py
@@ -1,6 +1,7 @@
 import functools
 import time
 import os
+import re
 
 
 def report_execution_time(step_name: str):
@@ -25,3 +26,15 @@ def from_here(config_file, input_file):
         input_file = os.path.normpath(os.path.join(from_here, input_file))
 
     return input_file
+
+def get_r_safename(name: str) -> str:
+    """Converts a string to a syntactically valid R name
+
+    This can be used to match names along axes of DataFrames produced by R,
+    assuming that the R script takes no measures to preserve names itself.
+    https://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html
+    """
+
+    leading_char = lambda x: re.sub(r"^(?=[^a-zA-Z.]+|\.\d)", "X", x)
+    special_char = lambda x: re.sub(r"[^a-zA-Z0-9_.]", ".", x)
+    return special_char(leading_char(name))


### PR DESCRIPTION
This PR introduces the following:
- One PCA plot per run (formerly, one per comparison which is incorrect and redundant)
- Original sample names are preserved in output tables. This is reflected in Plotter's sample labels/titles.
- Plotter no longer expects sanitized sample names
- Relative paths are accepted for the input feature counts csv
- Command line option --drop-zero which drops all rows/features which have a zero count across all libraries