### PR TITLE
Counter: command line arg added for showing all features in output counts

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -212,8 +212,8 @@ shared_memory: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: save intermediate table for each library with all alignment information --##
-intermed_file: False
+##-- If True: all features will be represented in the counts table, regardless --##
+counter_all_features: False
 
 ##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
 counter_diags: False

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -212,8 +212,8 @@ shared_memory: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: save intermediate table for each library with all alignment information --##
-intermed_file: False
+##-- If True: all features will be represented in the counts table, regardless --##
+counter_all_features: False
 
 ##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
 counter_diags: False

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -4,7 +4,6 @@ cwlVersion: v1.0
 class: CommandLineTool
 
 requirements:
-  - class: InlineJavascriptRequirement
   - class: InitialWorkDirRequirement
     listing: [
       $(inputs.gff_files),
@@ -20,38 +19,32 @@ inputs:
     type: File
     inputBinding:
       prefix: -i
-      position: 0
 
   config_csv:
     type: File
     inputBinding:
       prefix: -c
-      position: 1
 
   out_prefix:
     type: string
     inputBinding:
-      position: 2
       prefix: -o
 
-  intermed_file:
+  # Optional inputs
+
+  all_features:
     type: boolean?
     inputBinding:
-      position: 3
-      prefix: -t
+      prefix: -a
 
   is_pipeline:
     type: boolean?
-    default: false
     inputBinding:
-      position: 4
       prefix: -p
 
   diagnostics:
     type: boolean?
-    default: false
     inputBinding:
-      position: 5
       prefix: -d
 
   # The following optional inputs are for staging InitialWorkingDir files for pipeline execution

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -76,11 +76,11 @@ inputs:
   # counter inputs
   samples_csv: File
   features_csv: File
-  intermed_file: boolean?
   gff_files: File[]?
   aligned_seqs: File[]?
   is_pipeline: boolean?
   counter_diags: boolean?
+  counter_all_features: boolean?
 
   # deseq inputs
   control_condition: string?
@@ -201,16 +201,16 @@ steps:
   counter:
     run: ../tools/tiny-count.cwl
     in:
-      aligned_seqs: counter-prep/aln_seqs
-      gff_files: gff_files
       samples_csv: samples_csv
       config_csv: features_csv
+      aligned_seqs: counter-prep/aln_seqs
+      gff_files: gff_files
       out_prefix: run_name
-      intermed_file: intermed_file
-      fastp_logs: counter-prep/json_report_file
-      collapsed_fa: counter-prep/uniq_seqs
+      all_features: counter_all_features
       is_pipeline: {default: true}
       diagnostics: counter_diags
+      fastp_logs: counter-prep/json_report_file
+      collapsed_fa: counter-prep/uniq_seqs
     out: [feature_counts, other_counts, alignment_stats, summary_stats, intermed_out_files, alignment_diags, selection_diags]
 
   dge:

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -31,6 +31,9 @@ def get_args():
                         help='output prefix to use for file names')
 
     # Optional arguments
+    arg_parser.add_argument('-a', '--all-features', action='store_true',
+                        help='Represent all features in output counts table, '
+                             'regardless of counts or identity rules.')
     arg_parser.add_argument('-p', '--is-pipeline', action='store_true',
                         help='Indicates that counter was invoked from the tinyrna pipeline '
                              'and that input files should be sources as such.')
@@ -162,11 +165,11 @@ def main():
         # Assign and count features using multiprocessing and merge results
         merged_counts = map_and_reduce(libraries)
 
-        # Print any warnings that have accumulated
-        merged_counts.print_warnings()
+        # Determine which features should be represented in the counts table
+        display_indexes = Features.attributes.keys() if args.all_features else \
+                          FeatureSelector.get_all_identity_matches()
 
         # Write final outputs
-        display_indexes = FeatureSelector.get_all_identity_matches()
         merged_counts.write_report_files(display_indexes, Features.aliases)
     except:
         traceback.print_exception(*sys.exc_info())

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -5,18 +5,15 @@ import sys
 import os
 
 from collections import defaultdict
-from typing import Tuple
+from typing import Tuple, List, Dict
 
-from tiny.rna.counter.features import Features, FeatureCounter
-from tiny.rna.counter.hts_parsing import SelectionRules, FeatureSources
+from tiny.rna.counter.features import Features, FeatureCounter, FeatureSelector
 from tiny.rna.counter.statistics import SummaryStats
 from tiny.rna.util import report_execution_time, from_here
 from tiny.rna.configuration import CSVReader
 
 # Global variables for multiprocessing
 feature_counter: FeatureCounter
-is_pipeline = False
-run_diags = False
 
 
 def get_args():
@@ -41,15 +38,27 @@ def get_args():
                         help='Produce diagnostic information about uncounted/eliminated '
                              'selection elements.')
 
-    parsed_args = arg_parser.parse_args()
-
-    global is_pipeline, run_diags
-    is_pipeline = parsed_args.is_pipeline
-    run_diags = parsed_args.diagnostics
     return arg_parser.parse_args()
 
 
-def load_samples(samples_csv: str) -> list:
+def load_samples(samples_csv: str, is_pipeline: bool) -> List[Dict[str, str]]:
+    """Parses the Samples Sheet to determine library names and alignment files for counting
+
+    Sample files may have a .fastq(.gz) extension (i.e. when Counter is called as part of a
+    pipeline run) or a .sam extension (i.e. when Counter is called as a standalone tool).
+
+    Args:
+        samples_csv: a csv file which defines sample group, replicate, and file location
+        is_pipeline: helps locate sample SAM files. If true, files are assumed to reside
+            in the working directory. If false, files are assumed to reside in the same
+            directory as their source FASTQ files with '_aligned_seqs.sam' appended
+            (i.e. /dir/sample1.fastq -> /dir/sample1_aligned_seqs.sam).
+
+    Returns:
+        inputs: a list of dictionaries for each library, where each dictionary defines the
+        library name and the location of its SAM file for counting.
+    """
+
     def get_library_filename(csv_row_file: str, samples_csv: str) -> str:
         """The input samples.csv may contain either fastq or sam files"""
 
@@ -80,14 +89,18 @@ def load_samples(samples_csv: str) -> list:
     return inputs
 
 
-def load_config(features_csv: str) -> Tuple[SelectionRules, FeatureSources]:
-    """Parses features.csv to provide inputs to FeatureSelector and build_reference_tables
+def load_config(features_csv: str, is_pipeline: bool) -> Tuple[List[dict], Dict[str, list]]:
+    """Parses the Features Sheet to provide inputs to FeatureSelector and build_reference_tables
 
     Args:
         features_csv: a csv file which defines feature sources and selection rules
+        is_pipeline: helps locate GFF files defined in the Features Sheet. If true,
+            GFF files are assumed to reside in the working directory.
 
     Returns:
-        rules: a list of dictionaries, each representing a parsed row from input
+        rules: a list of dictionaries, each representing a parsed row from input.
+            Note that these are just rule definitions which FeatureSelector will
+            further digest to produce its rules table.
         gff_files: a dict of GFF files and associated Name Attribute preferences
     """
 
@@ -137,10 +150,10 @@ def main():
 
     try:
         # Determine SAM inputs and their associated library names
-        libraries = load_samples(args.input_csv)
+        libraries = load_samples(args.input_csv, args.is_pipeline)
 
         # Load selection rules and feature sources from config
-        selection_rules, gff_file_set = load_config(args.config)
+        selection_rules, gff_file_set = load_config(args.config, args.is_pipeline)
 
         # global for multiprocessing
         global feature_counter
@@ -153,7 +166,8 @@ def main():
         merged_counts.print_warnings()
 
         # Write final outputs
-        merged_counts.write_report_files(feature_counter.alias, args.out_prefix)
+        display_indexes = FeatureSelector.get_all_identity_matches()
+        merged_counts.write_report_files(display_indexes, Features.aliases)
     except:
         traceback.print_exception(*sys.exc_info())
         print("\n\nCounter encountered an error. Don't worry! You don't have to start over.\n"

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -2,16 +2,15 @@ import itertools
 import HTSeq
 
 from collections import defaultdict
-from typing import List, Tuple, Set
+from typing import List, Tuple, Set, Dict, Iterator
 
 import tiny.rna.counter.hts_parsing as parser
-from .selectors import Wildcard, StrandMatch, NumericalMatch, NtMatch
+from .matching import Wildcard, StrandMatch, NumericalMatch, NtMatch
 from .statistics import LibraryStats
+from ..util import report_execution_time
 
 # Type aliases for human readability
-IntervalFeatures = Tuple[int, int, Set[str]]  # A set of features associated with an interval
-AssignedFeatures = set
-N_Candidates = int
+Hit = Tuple[int, int, str]
 
 BOTH_STRANDS = ('+', '-')
 
@@ -23,12 +22,15 @@ class Features:
     chrom_vectors: HTSeq.ChromVector
     attributes: dict
     intervals: dict
+    aliases: dict
+
     _instance = None  # Singleton
 
-    def __init__(self, features: HTSeq.GenomicArrayOfSets, attributes: dict, intervals: dict):
+    def __init__(self, features: HTSeq.GenomicArrayOfSets, attributes: dict, aliases: dict, intervals: dict):
         if Features._instance is None:
             Features.chrom_vectors = features.chrom_vectors  # For interval -> feature ID lookups
             Features.attributes = attributes                 # For feature ID -> GFF column 9 attribute lookups
+            Features.aliases = aliases                       # For feature ID -> preferred feature name lookups
             Features.intervals = intervals                   # For feature ID -> interval lookups
             Features._instance = self
 
@@ -36,20 +38,18 @@ class Features:
 class FeatureCounter:
     out_prefix: str
     run_diags: bool
-    alias: dict
 
     def __init__(self, gff_file_set, selection_rules, run_diags, out_prefix):
         reference_tables = parser.build_reference_tables(gff_file_set, selection_rules)
-        Features(reference_tables[0], reference_tables[1], reference_tables[3])
+        Features(*reference_tables)
 
-        FeatureCounter.alias = reference_tables[2]
         FeatureCounter.out_prefix = out_prefix
         FeatureCounter.run_diags = run_diags
 
         self.stats = LibraryStats(out_prefix, report_diags=run_diags)
         self.selector = FeatureSelector(selection_rules, self.stats, diags=run_diags)
 
-    def assign_features(self, alignment: 'parser.Alignment') -> Tuple[AssignedFeatures, N_Candidates]:
+    def assign_features(self, alignment: 'parser.Alignment') -> Tuple[set, int]:
         """Determines features associated with the interval then performs rule-based feature selection"""
 
         feat_matches, assignment = list(), set()
@@ -114,7 +114,7 @@ class FeatureSelector:
     Hits are tuples for performance reasons, and are of the format:
         (hierarchy, rule, feature_id)
 
-    If more than one hit remains following first round selection, a second round of selection
+    If more than one Hit remains following first round selection, a second round of selection
     is performed against sequence attributes: strand, 5' end nucleotide, and length. Rules for
     5' end nucleotides support lists (e.g. C,G,U) and wildcards (e.g. "all"). Rules for length
     support lists, wildcards, and ranges (i.e. 20-27) which may be intermixed in the same rule.
@@ -122,15 +122,17 @@ class FeatureSelector:
     by the alignment interval.
     """
 
-    def __init__(self, rules: List[dict], libstats: 'LibraryStats', diags=False):
-        self.rules_table = self.build_selectors(rules)
-        self.inv_ident = self.build_inverted_identities(self.rules_table)
+    rules_table = dict()
+    inv_ident = dict()
 
-        self.phase1_candidates = libstats.identity_roster
+    def __init__(self, rules: List[dict], libstats: 'LibraryStats', diags=False):
+        FeatureSelector.rules_table = self.build_selectors(rules)
+        FeatureSelector.inv_ident = self.build_inverted_identities(FeatureSelector.rules_table)
+
         self.report_eliminations = diags
         if diags: self.elim_stats = libstats.diags.selection_diags
 
-    def choose(self, feat_list: List[IntervalFeatures], alignment: 'parser.Alignment') -> set:
+    def choose(self, feat_list: List[Tuple[int, int, Set[str]]], alignment: 'parser.Alignment') -> Set[str]:
         # Perform hierarchy-based first round of selection for identities
         finalists = self.choose_identities(feat_list, alignment.iv)
         if not finalists: return set()
@@ -147,7 +149,7 @@ class FeatureSelector:
                 if selector == "Strand":
                     feat_strand = Features.intervals[hit[FEAT]].strand
                     read = (read[0], feat_strand)
-                if read not in self.rules_table[hit[RULE]][selector]:
+                if read not in FeatureSelector.rules_table[hit[RULE]][selector]:
                     eliminated.add(hit)
                     if self.report_eliminations:
                         feat_class = Features.attributes[hit[FEAT]][0][1][0]
@@ -162,19 +164,19 @@ class FeatureSelector:
         return {choice[FEAT] for choice in finalists}
 
     @staticmethod
-    def is_perfect_iv_match(feat_start, feat_end, aln_iv):
-        # Only accept perfect interval matches for rules requiring such
+    def is_perfect_iv_match(feat_start, feat_end, aln_iv) -> bool:
+        # Returns true if the alignment interval is fully enclosed by the feature interval
         return feat_start <= aln_iv.start and feat_end >= aln_iv.end
 
-    def choose_identities(self, feats_list: List[IntervalFeatures], aln_iv: 'HTSeq.GenomicInterval'):
+    def choose_identities(self, feats_list: List[Tuple[int, int, Set[str]]], aln_iv: 'HTSeq.GenomicInterval') -> Set[Hit]:
         """Performs the initial selection on the basis of identity rules: attribute (key, value)
 
         Feature candidates are supplied to this function via feats_list. This is a list
-        of tuples, each representing features associated with an in interval which
+        of tuples, each representing features associated with an interval which
         overlapped the alignment interval. The interval in this tuple may be a partial
         (incomplete) overlap with the alignment.
 
-        The list of IntervalFeatures takes the following form:
+        The feats_list takes the following form:
             [(iv_A_start, iv_A_end, {features, associated, with, iv_A, ... }),
              (iv_B_start, iv_B_end, {features, associated, with, iv_B, ... }), ... ]
             Where iv_A and iv_B overlap aln_iv by at least 1 base
@@ -186,35 +188,26 @@ class FeatureSelector:
                 assign features.
 
         Returns:
-
+            identity_hits: a set of Hits for features which matched an identity rule,
+            after performing elimination by hierarchy.
         """
 
         finalists, identity_hits = set(), list()
-        start, end, features = 0, 1, 2  # IntervalFeatures tuple indexes
 
         for iv_feats in feats_list:
             # Check for perfect interval match only once per IntervalFeatures
-            perfect_iv_match = self.is_perfect_iv_match(iv_feats[start], iv_feats[end], aln_iv)
-            for feat in iv_feats[features]:
+            perfect_iv_match = self.is_perfect_iv_match(iv_feats[0], iv_feats[1], aln_iv)
+            for feat in iv_feats[2]:
                 for attrib in Features.attributes[feat]:
-                    # If multiple values are associated with the attribute key, create their key/value products
-                    for feat_ident in itertools.product([attrib[0]], attrib[1]):
-                        try:
-                            # Check if rules are defined for this feature identity
-                            for rule in self.inv_ident[feat_ident]:
-                                if not perfect_iv_match and self.rules_table[rule]['Strict']:
-                                    continue
-                                identity_hits.append((self.rules_table[rule]['Hierarchy'], rule, feat))
-                        except KeyError:
-                            pass
+                    for rule in self.get_identity_matches(attrib):
+                        if not perfect_iv_match and FeatureSelector.rules_table[rule]['Strict']:
+                            continue
+                        identity_hits.append((FeatureSelector.rules_table[rule]['Hierarchy'], rule, feat))
         # -> identity_hits: [(hierarchy, rule, feature), ...]
 
-        self.phase1_candidates.update(hit[FEAT] for hit in identity_hits)
-
-        # Only one feature matched only one rule
+        # Perform hierarchy-based elimination
         if len(identity_hits) == 1:
             finalists.add(identity_hits[0])
-        # Perform any possible hierarchy-based eliminations
         elif len(identity_hits) > 1:
             uniq_ranks = {hit[RANK] for hit in identity_hits}
 
@@ -226,6 +219,46 @@ class FeatureSelector:
                 finalists.update(hit for hit in identity_hits if hit[RANK] == min_rank)
 
         return finalists
+
+    @classmethod
+    def get_identity_matches(cls, attribute) -> Iterator[int]:
+        """Returns indexes of rules associated with a feature attribute record
+
+        An attribute record is of the form ('key', ('value1', 'value2', ...)) where
+        one or more values may be associated with the key. If there are multiple values,
+        key-value products are formed, i.e. ('key', 'value1'), ('key', 'value2'), ...,
+        for lookup in the inverted identities table. In this way multiple identities may
+        be produced from a single attribute record. If any identity product matches a
+        rule in the inverted identities table, the indexes of the associated selection
+        rules are returned
+        """
+
+        # First iterator is a string wrapped in in iterable to prevent iteration of its characters
+        for feat_ident in itertools.product([attribute[0]], attribute[1]):
+            try:
+                # Check if rules are defined for this feature identity
+                for identity_rule in cls.inv_ident[feat_ident]:
+                    yield identity_rule
+            except KeyError:
+                pass
+
+    @classmethod
+    @report_execution_time("Determining output table index")
+    def get_all_identity_matches(cls) -> Set[str]:
+        """Returns all features which match an identity rule in the rules table"""
+
+        matches = set()
+        for feat, feat_attrs in Features.attributes.items():
+            for attr in feat_attrs:
+                ident_matches = cls.get_identity_matches(attr)
+                try:
+                    next(ident_matches)
+                    matches.add(feat)
+                except StopIteration:
+                    # No rules defined for this identity
+                    pass
+
+        return matches
 
     @staticmethod
     def build_selectors(rules_table) -> List[dict]:
@@ -253,7 +286,7 @@ class FeatureSelector:
         return rules_table
 
     @staticmethod
-    def build_inverted_identities(rules_table) -> dict:
+    def build_inverted_identities(rules_table) -> Dict[Tuple[str, str], List[int]]:
         """Builds inverted identity rules for fast matching in phase 1 selection
 
         The resulting dictionary has (Attrib Key, Attrib Val) as key, [associated rule indexes] as val
@@ -265,7 +298,7 @@ class FeatureSelector:
 
         return dict(inverted_identities)
 
-    @classmethod
-    def get_hit_indexes(cls):
+    @staticmethod
+    def get_hit_indexes() -> Tuple[int, int, int]:
         """Hits are stored as tuples for performance. This returns a human friendly index map for the tuple."""
         return RANK, RULE, FEAT

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -7,7 +7,6 @@ from typing import List, Tuple, Set, Dict, Iterator
 import tiny.rna.counter.hts_parsing as parser
 from .matching import Wildcard, StrandMatch, NumericalMatch, NtMatch
 from .statistics import LibraryStats
-from ..util import report_execution_time
 
 # Type aliases for human readability
 Hit = Tuple[int, int, str]
@@ -243,7 +242,6 @@ class FeatureSelector:
                 pass
 
     @classmethod
-    @report_execution_time("Determining output table index")
     def get_all_identity_matches(cls) -> Set[str]:
         """Returns all features which match an identity rule in the rules table"""
 

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -12,13 +12,6 @@ from tiny.rna.util import report_execution_time
 _re_attr_main = re.compile(r"\s*([^\s=]+)[\s=]+(.*)")
 _re_attr_empty = re.compile(r"^\s*$")
 
-# Type aliases for human readability
-Features = HTSeq.GenomicArrayOfSets  # interval -> set of associated features
-Attributes = Dict[str, list]  # feature -> feature attributes
-FeatureSources = Dict[str, list]
-SelectionRules = List[dict]
-Alias = dict
-
 
 class Alignment:
     """The data structure in which parsed SAM alignments are stored.
@@ -158,7 +151,8 @@ def parse_GFF_attribute_string(attrStr, extra_return_first_value=False):
 
 
 @report_execution_time("GFF parsing")
-def build_reference_tables(gff_files: FeatureSources, rules: SelectionRules) -> Tuple[Features, Attributes, Alias, Dict]:
+def build_reference_tables(gff_files: Dict[str, list], rules: List[dict]) \
+        -> Tuple['HTSeq.GenomicArrayOfSets', Dict[str, list], dict, dict]:
     """A GFF parser which builds feature, attribute, and alias tables, with intelligent appends
 
     Features may be defined by multiple GFF files. If multiple files offer different attributes for

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -46,7 +46,7 @@ class NumericalMatch(frozenset):
     """For evaluating sequence length against a list and/or range of desired values
 
     FeatureSelector will determine a match by checking the frozenset
-    superclass's __contains__() function. Tuples are more lightweight for a small range of possible values.
+    superclass's __contains__() function. Frozensets have marginally faster lookup for wider ranges of values.
     """
 
     def __new__(cls, lengths):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -121,6 +121,7 @@ class SummaryStats:
             self.selection_diags = {}
 
     def write_report_files(self, counts_idx: set, alias: dict) -> None:
+        self.print_warnings()
         if self.report_diags:
             Diagnostics.write_summary(self.out_prefix, self.aln_diags, self.selection_diags)
 

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -212,8 +212,8 @@ shared_memory: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: save intermediate table for each library with all alignment information --##
-intermed_file: False
+##-- If True: all features will be represented in the counts table, regardless --##
+counter_all_features: False
 
 ##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
 counter_diags: False


### PR DESCRIPTION
Counter now has the option to show all features in the output counts table, regardless of count, identity rules, or associated alignments.

This PR also cleans up details from previous issues, including the removal of Counter's "intermediate files" option from the CWL.