### PR TITLE
Unit tests bugfix for GitHub Actions environment

### DIFF
--- a/tests/unit_tests_entry.py
+++ b/tests/unit_tests_entry.py
@@ -33,7 +33,10 @@ class test_entry(unittest.TestCase):
         self.templates_path = '../tiny/templates'
 
         # For post-install tests
-        os.system("pip install -e ../ > /dev/null")
+        if os.environ.get('GITHUB_ACTIONS', None) != 'true':
+            print("Tests are being run locally, refreshing installation...")
+            os.system("pip install -e ../ > /dev/null")
+            print("Done.")
 
         # For both pre and post install
         self.config_file = './testdata/run_config_template.yml'


### PR DESCRIPTION
unit_tests_entry will refresh the project's pip installation since it directly tests the tinyRNA commands via shell. We don't want this to happen on GitHub Actions because unit tests immediately follow the fresh installation of the project.

Merging my own PR since this has virtually no effect on the codebase