### PR TITLE
Deseq: bidirectional DGE tables for all-experimental runs, improved PCA plots

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -233,8 +233,8 @@ counter_diags: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison --##
-dge_pca_plots: True
+##-- If True: produce a principal component analysis plot from the input dataset --##
+dge_pca_plot: True
 
 ##-- If True: before analysis, drop features which have a zero count across all samples --##
 dge_drop_zero: False

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -233,8 +233,8 @@ counter_diags: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison --##
-dge_pca_plots: True
+##-- If True: produce a principal component analysis plot from the input dataset --##
+dge_pca_plot: True
 
 ##-- If True: before analysis, drop features which have a zero count across all samples --##
 dge_drop_zero: False

--- a/tiny/cwl/tools/tiny-deseq.cwl
+++ b/tiny/cwl/tools/tiny-deseq.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 
 baseCommand: tiny-deseq.r
 stdout: console_output.log
-stderr: console_output.log
+#stderr: console_output.log
 
 inputs:
   input_file:
@@ -26,11 +26,11 @@ inputs:
       prefix: --control
     doc: If specified, comparisons will only be made against the control condition
 
-  plots:
+  pca:
     type: boolean?
     inputBinding:
       prefix: --pca
-    doc: Produce PCA plots for each library comparison
+    doc: Produce a PCA plot from the input dataset
 
   drop_zero:
     type: boolean?
@@ -49,8 +49,8 @@ outputs:
     outputBinding:
       glob: $(inputs.outfile_prefix)_*_*_deseq_table.csv
 
-  pca_plots:
-    type: File[]?
+  pca_plot:
+    type: File?
     outputBinding:
       glob: $(inputs.outfile_prefix)_pca_plot.pdf
 

--- a/tiny/cwl/workflows/organize-outputs.cwl
+++ b/tiny/cwl/workflows/organize-outputs.cwl
@@ -55,7 +55,7 @@ inputs:
 
   dge_name: string?
   dge_norm: File?
-  dge_pca: File[]?
+  dge_pca: File?
   dge_comparisons: File[]?
   dge_console: File?
 
@@ -133,7 +133,7 @@ steps:
     when: $(inputs.dir_name != null)
     in:
       dir_files:
-        source: [ dge_norm, dge_comparisons, dge_pca, dge_console ]
+        source: [ dge_norm, dge_comparisons, dge_console ]
         linkMerge: merge_flattened
         pickValue: all_non_null
         valueFrom: ${if (self.length == 1){return [self];} else {return self}}
@@ -145,7 +145,7 @@ steps:
     when: $(inputs.dir_name != null)
     in:
       dir_files:
-        source: [ plotter_plots, plotter_console ]
+        source: [ plotter_plots, plotter_console, dge_pca ]
         linkMerge: merge_flattened
         pickValue: all_non_null
         valueFrom: ${if (self.length == 1){return [self];} else {return self}}

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -80,7 +80,7 @@ inputs:
 
   # deseq inputs
   control_condition: string?
-  dge_pca_plots: boolean?
+  dge_pca_plot: boolean?
   dge_drop_zero: boolean?
 
   # plotter options
@@ -231,9 +231,9 @@ steps:
       input_file: counter/feature_counts
       outfile_prefix: run_name
       control: control_condition
-      plots: dge_pca_plots
+      pca: dge_pca_plot
       drop_zero: dge_drop_zero
-    out: [ norm_counts, comparisons, pca_plots, console_output ]
+    out: [ norm_counts, comparisons, pca_plot, console_output ]
 
   dge-subdir:
     run: organize-outputs.cwl
@@ -241,7 +241,6 @@ steps:
       dge_name: dir_name_dge
       dge_norm: dge/norm_counts
       dge_comparisons: dge/comparisons
-      dge_pca: dge/pca_plots
       dge_console: dge/console_output
     out: [dge_dir]
 
@@ -262,6 +261,7 @@ steps:
       plotter_name: dir_name_plotter
       plotter_plots: plotter/plots
       plotter_console: plotter/console_output
+      dge_pca: dge/pca_plot
     out: [plotter_dir]
 
 outputs:

--- a/tiny/rna/tiny-deseq.r
+++ b/tiny/rna/tiny-deseq.r
@@ -115,8 +115,14 @@ deseq_run <- DESeq2::DESeq(deseq_ds)
 
 ## Produce PCA plot if requested
 if (plot_pca){
-  plt <- DESeq2::plotPCA(DESeq2::vst(deseq_ds)) + ggplot2::theme(aspect.ratio = 1)
-  ggsave(paste(out_pref, "pca_plot.pdf", sep="_"))
+  vst_res <- tryCatch(
+    DESeq2::vst(deseq_ds),
+    error=function(e) {
+      return(DESeq2::varianceStabilizingTransformation(deseq_ds))
+  })
+
+  plt <- DESeq2::plotPCA(vst_res) + ggplot2::theme(aspect.ratio = 1)
+  ggplot2::ggsave(paste(out_pref, "pca_plot.pdf", sep="_"))
 }
 
 ## Get normalized counts and write them to CSV with original sample names in header

--- a/tiny/rna/tiny-deseq.r
+++ b/tiny/rna/tiny-deseq.r
@@ -99,7 +99,7 @@ if (has_control && !(control_grp %in% sampleConditions)){
 
 ## Now that inputs have been validated and read, load libraries
 library(DESeq2)
-library(lattice)
+library(ggplot2)
 library(utils)
 
 ## Create the deseqdataset
@@ -115,9 +115,8 @@ deseq_run <- DESeq2::DESeq(deseq_ds)
 
 ## Produce PCA plot if requested
 if (plot_pca){
-    plt <- plotPCA(DESeq2::rlog(deseq_ds))
-    trellis.device(device="pdf", file=paste(out_pref, "pca_plot.pdf", sep="_"))
-    print(plt)
+  plt <- DESeq2::plotPCA(DESeq2::vst(deseq_ds)) + ggplot2::theme(aspect.ratio = 1)
+  ggsave(paste(out_pref, "pca_plot.pdf", sep="_"))
 }
 
 ## Get normalized counts and write them to CSV with original sample names in header
@@ -133,11 +132,8 @@ if (has_control){
     unique(names(sampleConditions[sampleConditions != r_safe_control_name]))
   ))
 } else {
-  # Comparison is all combinations of conditions interleaved with the reverse comparisons
+  # Comparison is all combinations of conditions
   all_comparisons <- t(combn(unique(names(sampleConditions)), 2))
-  # comparisons <- rbind(comparisons, comparisons[, ncol(comparisons):1])
-  # interleave_rows <- order(sequence(rep(nrow(comparisons) / 2, 2)))
-  # all_comparisons <- comparisons[interleave_rows, ]
 }
 
 write_dge_table <- function (dge_df, cond1, cond2){

--- a/tiny/rna/tiny-deseq.r
+++ b/tiny/rna/tiny-deseq.r
@@ -37,7 +37,7 @@ df_with_classes <- function(classless_df){
 }
 
 ## Throw an error if an unexpected number of arguments is provided
-if (length(args) > 7){
+if (length(args) > 8){
   stop(gettextf("Too many arguments given. %d arguments were parsed.
   Was there an unquoted space in your arguments?\n\n%s", length(args), usage))
 } else if (length(args) < 4){

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -233,8 +233,8 @@ counter_diags: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison --##
-dge_pca_plots: True
+##-- If True: produce a principal component analysis plot from the input dataset --##
+dge_pca_plot: True
 
 ##-- If True: before analysis, drop features which have a zero count across all samples --##
 dge_drop_zero: False


### PR DESCRIPTION
- If a control group is not specified, a DGE table is produced for both directions of each pairwise comparison
- PCA plots are now produced using the variance stabilizing transform rather than regularized log transform
- PCA plots are now produced more reliably, and with a 1:1 aspect ratio regardless of PC1/PC2 range
- PCA plots are now placed in the Plotter output directory rather than the DGE output directory

Closes #103 