### PR TITLE
Plotter: optional p-value command line arg added

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -262,8 +262,11 @@ plot_requests:
   - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_dge_class'
 
-##-- You may supply your own matplotlib style sheet to override defaults here --##
+##-- You can supply your own matplotlib style sheet to override defaults here --##
 plot_style_sheet: ~
+
+##-- You can set a custom p-value to use in DGE scatter plots. Default: 0.05 --##
+plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -262,8 +262,11 @@ plot_requests:
   - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_dge_class'
 
-##-- You may supply your own matplotlib style sheet to override defaults here --##
+##-- You can supply your own matplotlib style sheet to override defaults here --##
 plot_style_sheet: ~
+
+##-- You can set a custom p-value to use in DGE scatter plots. Default: 0.05 --##
+plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False

--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -26,6 +26,12 @@ inputs:
       prefix: -len
     doc: "5' end nucleotide vs. length matrices from Counter"
 
+  dge_pval:
+    type: float?
+    inputBinding:
+      prefix: -pv
+    doc: "The p-value to use for DGE scatter plots (default: 0.05)"
+
   style_sheet:
     type: File?
     inputBinding:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -86,6 +86,7 @@ inputs:
   # plotter options
   plot_requests: string[]
   plot_style_sheet: File?
+  plot_pval: float?
 
   # output directory names
   dir_name_bt_build: string
@@ -250,6 +251,7 @@ steps:
       norm_counts: dge/norm_counts
       dge_tables: dge/comparisons
       len_dist: counter/other_counts
+      dge_pval: plot_pval
       style_sheet: plot_style_sheet
       out_prefix: run_name
       plot_requests: plot_requests

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -42,6 +42,8 @@ def get_args():
     # Outputs options
     parser.add_argument('-o', '--out-prefix', metavar='OUTPREFIX',
                         help='Optional prefix to use for output PDF files.')
+    parser.add_argument('-pv', '--p-value', metavar='VAL', default=0.05, type=float,
+                        help='Optional p-value to use in DGE scatter plots.')
     parser.add_argument('-s', '--style-sheet', metavar='MPLSTYLE',
                         default=resource_filename('tiny', 'templates/tinyrna-light.mplstyle'),
                         help='Optional matplotlib style sheet to use for plots.')
@@ -241,7 +243,7 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             for cls in uniq_classes:
                 grp_args.append(list(class_dges.index[class_dges == cls]))
 
-            labels = ['p ≥ %.2f' % pval] + uniq_classes
+            labels = ['p ≥ %g' % pval] + uniq_classes
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, *grp_args,
                                           log_norm=True, labels=labels, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
@@ -255,7 +257,7 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             grp_args = list(dges.index[dges[pair] < pval])
             p1, p2 = pair.split("_vs_")
 
-            labels = ['p ≥ %.2f' % pval, 'p < %.2f' % pval]
+            labels = ['p ≥ %g' % pval, 'p < %g' % pval]
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, grp_args,
                                           log_norm=True, labels=labels, alpha=0.5, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
@@ -423,11 +425,11 @@ def main():
         elif plot == 'sample_avg_scatter_by_dge':
             func = scatter_dges
             arg = (inputs["norm_count_avg_df"], inputs["de_table"], args.out_prefix, inputs["avg_view_lims"])
-            kwd = {}
+            kwd = {"pval": args.p_value}
         elif plot == 'sample_avg_scatter_by_dge_class':
             func = scatter_dges
             arg = (inputs["norm_count_avg_df"], inputs["de_table"], args.out_prefix, inputs["avg_view_lims"])
-            kwd = {"classes": inputs["feat_classes"]}
+            kwd = {"classes": inputs["feat_classes"], "pval": args.p_value}
         else:
             print('Plot type %s not recognized, please check the -p/--plot arguments' % plot)
             continue

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -20,7 +20,7 @@ if curr_locale[0] is None:
     # Default locale otherwise unset
     os.environ['LC_CTYPE'] = 'en_US.UTF-8'
 
-import matplotlib as mpl
+import matplotlib as mpl; mpl.use("PDF")
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tix
 import matplotlib.axis
@@ -38,11 +38,6 @@ class plotterlib:
         if debug:
             mpl.use("TkAgg", force=True)
             mpl.rcParams['savefig.dpi'] = 100
-        else:
-            mpl.use("PDF", force=True)
-
-        # Must occur after mpl.use()
-        import matplotlib.pyplot as plt
 
         # Set global plot style once
         plt.style.use(user_style_sheet)

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -189,5 +189,10 @@ class ResumePlotterConfig(ResumeConfig):
             self['resume_norm'] = self.cwl_file(glob(dge + "/*_norm_counts.csv")[0])
             self['resume_len_dist'] = list(map(self.cwl_file, glob(counter + "/*_nt_len_dist.csv")))
             self['resume_dge'] = list(map(self.cwl_file, glob(dge + "/*_deseq_table.csv")))
-        except (FileNotFoundError, IndexError) as e:
+        except FileNotFoundError as e:
             sys.exit("The following pipeline output could not be found:\n%s" % (e.filename,))
+        except IndexError:
+            msg = "Expected outputs for feature counts or norm counts could not be found. "
+            if counter is None or not os.path.isdir(counter): msg += f"The directory {counter} was not found. "
+            if dge is None or not os.path.isfile(dge): msg += f"The directory {dge} was not found. "
+            sys.exit(msg)

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -262,8 +262,11 @@ plot_requests:
   - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_dge_class'
 
-##-- You may supply your own matplotlib style sheet to override defaults here --##
+##-- You can supply your own matplotlib style sheet to override defaults here --##
 plot_style_sheet: ~
+
+##-- You can set a custom p-value to use in DGE scatter plots. Default: 0.05 --##
+plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False


### PR DESCRIPTION
The p-value is used to determine the outgroup (and legend label) in DGE scatter plots. P-values with variable precision are accepted. Values with greater than 4 decimal points of precision are formatted with scientific notation in the plot legend.

Closes #104 