### PR TITLE
bowtie-build now runs parallel to fastp, Collapser

### DIFF
--- a/tiny/cwl/workflows/per-library.cwl
+++ b/tiny/cwl/workflows/per-library.cwl
@@ -36,26 +36,6 @@ inputs:
   threshold: int?
   compress: boolean?
 
-  # bowtie inputs
-  bt_index_files: File[]
-  ebwt: string
-  fastq: boolean?
-  fasta: boolean?
-  trim5: int?
-  trim3: int?
-  bt_phred64: boolean?
-  solexa: boolean?
-  solexa13: boolean?
-  end_to_end: int?
-  nofw: boolean?
-  norc: boolean?
-  k_aln: int?
-  all_aln: boolean?
-  no_unal: boolean?
-  sam: boolean?
-  seed: int?
-  shared_memory: boolean?
-
 steps:
   fastp:
     run: ../tools/fastp.cwl
@@ -95,34 +75,6 @@ steps:
       compress: compress
     out: [collapsed_fa, low_counts_fa, console_output]
 
-  bowtie:
-    run: ../tools/bowtie.cwl
-    in:
-      reads: collapse/collapsed_fa
-      sample_basename: sample_basename
-      bt_index_files: bt_index_files
-      ebwt: ebwt
-      outfile: {valueFrom: $(inputs.sample_basename + "_aligned_seqs.sam")}
-      logfile: {valueFrom: $(inputs.sample_basename + "_console_output.log")}
-      fastq: fastq
-      fasta: fasta
-      trim5: trim5
-      trim3: trim3
-      phred64: bt_phred64
-      solexa: solexa
-      solexa13: solexa13
-      end_to_end: end_to_end
-      nofw: nofw
-      k_aln: k_aln
-      all_aln: all_aln
-      no_unal: no_unal
-      un: {valueFrom: $(inputs.sample_basename + "_unaligned_seqs.fa")}
-      sam: sam
-      threads: threads
-      shared_memory: shared_memory
-      seed: seed
-    out: [sam_out, unal_seqs, console_output]
-
 outputs:
 
   fastq_clean:
@@ -149,19 +101,7 @@ outputs:
     type: File # unscatter
     outputSource: collapse/console_output
 
-  aln_seqs:
-    type: File # unscatter
-    outputSource: bowtie/sam_out
-
-  bowtie_console:
-    type: File # unscatter
-    outputSource: bowtie/console_output
-
   # Optional outputs
-  unal_seqs:
-    type: File?
-    outputSource: bowtie/unal_seqs
-
   uniq_seqs_low:
     type: File? # unscatter
     outputSource: collapse/low_counts_fa


### PR DESCRIPTION
The workflow has been modified such that bowtie runs as a scattered CommandLineTool rather than scattering inline with fastp and Collapser. This means that bowtie-build can run during the preprocessing steps for bowtie.

This creates a new problem. Before this change, the pipeline was parallelized library-wise across the fastp, Collapser, and bowtie steps. This meant that as soon as one library completed a step, it was able to move to the next step regardless of which step the other libraries were on. Ultimately all libraries needed to complete the bowtie step before Counter could begin.

Now, all libraries must complete the Collapser step before any of them can proceed to bowtie.
![Scatter Conundrum (1)](https://user-images.githubusercontent.com/63317/140205016-75876ccb-a546-4dfd-9a0e-3f8d4bb9bf03.png)

Ultimately the difference this makes is pretty minimal, especially since the same scenario is unavoidable at the Counter step, but it isn't ideal concurrency. I wrote a script to parse the CWL run log and produce a timeline for these parallel steps to illustrate the point:
![image](https://user-images.githubusercontent.com/63317/140206656-1ef7ed9d-d72b-4cb1-8619-e86fcbe1a257.png)

For now, I don't think this is worth fretting over any further. I've reached out to the CWL community to see if there is a better solution for this scenario which would allow bowtie to be integrated with the scatered subworkflow while also allowing bowtie-build to run in parallel.