### PR TITLE
Improved pipeline start time. More robust handling of output subdirectories.

### DIFF
--- a/tiny/cwl/tools/make-subdir.cwl
+++ b/tiny/cwl/tools/make-subdir.cwl
@@ -1,33 +1,44 @@
 #!/usr/bin/env cwl-runner
 
 ######-------------------------------------------------------------------------------######
-# This CommandLineTool converts an array of Files into a Directory output
-# It allows us to gather multiple files from a workflow step into a single subdirectory
-# No external tools are utilized. This is pure CWL.
+# This ExpressionTool returns a directory containing the files/directories provided.
+# The dir_files input is extremely flexible. It can contain a single file or directory,
+# or lists of files and/or directories, any of which may be or contain null values. Nested
+# lists are unpacked recursively. Directories are added as themselves rather than their
+# individual file listings.
 ######-------------------------------------------------------------------------------######
 
 cwlVersion: v1.2
-class: CommandLineTool
+class: ExpressionTool
 
 requirements:
   - class: InlineJavascriptRequirement
-  - class: ShellCommandRequirement
   - class: InitialWorkDirRequirement
     listing: $(inputs.dir_files)
 
-# This is effectively a no-op shell command
-arguments: [":"]
-
 inputs:
-  dir_files: File[]
+  dir_files: Any?
   dir_name: {type: string?, default: "default_dirname"}
 
 outputs:
-  subdir:
-    type: Directory
-    outputBinding:
-      # This glob pattern returns the enclosing temp dir
-      glob: "."
-      # Then we simply rename the enclosing temp dir and return it
-      outputEval: |
-        ${self[0].basename = inputs.dir_name; return self;}
+  subdir: Directory
+
+expression: |
+  ${
+    function add_array(files){
+      var listing = [];
+      for (var i in files){
+        var item = files[i]
+        if (item == null) continue;
+        if (Array.isArray(item)) listing.push.apply(listing, add_array(item));
+        if (["File", "Directory"].includes(item["class"])) listing.push(item);
+      }
+      return listing;
+    }
+
+    return {"subdir": {
+      "class": "Directory",
+      "basename": inputs.dir_name,
+      "listing": add_array([inputs.dir_files])
+    }}
+  }

--- a/tiny/cwl/workflows/per-library.cwl
+++ b/tiny/cwl/workflows/per-library.cwl
@@ -36,26 +36,6 @@ inputs:
   threshold: int?
   compress: boolean?
 
-  # bowtie inputs
-  bt_index_files: File[]
-  ebwt: string
-  fastq: boolean?
-  fasta: boolean?
-  trim5: int?
-  trim3: int?
-  bt_phred64: boolean?
-  solexa: boolean?
-  solexa13: boolean?
-  end_to_end: int?
-  nofw: boolean?
-  norc: boolean?
-  k_aln: int?
-  all_aln: boolean?
-  no_unal: boolean?
-  sam: boolean?
-  seed: int?
-  shared_memory: boolean?
-
 steps:
   fastp:
     run: ../tools/fastp.cwl
@@ -95,34 +75,6 @@ steps:
       compress: compress
     out: [collapsed_fa, low_counts_fa, console_output]
 
-  bowtie:
-    run: ../tools/bowtie.cwl
-    in:
-      reads: collapse/collapsed_fa
-      sample_basename: sample_basename
-      bt_index_files: bt_index_files
-      ebwt: ebwt
-      outfile: {valueFrom: $(inputs.sample_basename + "_aligned_seqs.sam")}
-      logfile: {valueFrom: $(inputs.sample_basename + "_console_output.log")}
-      fastq: fastq
-      fasta: fasta
-      trim5: trim5
-      trim3: trim3
-      phred64: bt_phred64
-      solexa: solexa
-      solexa13: solexa13
-      end_to_end: end_to_end
-      nofw: nofw
-      k_aln: k_aln
-      all_aln: all_aln
-      no_unal: no_unal
-      un: {valueFrom: $(inputs.sample_basename + "_unaligned_seqs.fa")}
-      sam: sam
-      threads: threads
-      shared_memory: shared_memory
-      seed: seed
-    out: [sam_out, unal_seqs, console_output]
-
 outputs:
 
   fastq_clean:
@@ -149,19 +101,7 @@ outputs:
     type: File # unscatter
     outputSource: collapse/console_output
 
-  aln_seqs:
-    type: File # unscatter
-    outputSource: bowtie/sam_out
-
-  bowtie_console:
-    type: File # unscatter
-    outputSource: bowtie/console_output
-
   # Optional outputs
-  unal_seqs:
-    type: File?
-    outputSource: bowtie/unal_seqs
-
   uniq_seqs_low:
     type: File? # unscatter
     outputSource: collapse/low_counts_fa

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -102,20 +102,6 @@ inputs:
 
 steps:
 
-  bt_build_optional:
-    run: ../tools/bowtie-build.cwl
-    when: $(inputs.run_bowtie_build)
-    in:
-      run_bowtie_build: run_bowtie_build
-      ref_in: reference_genome_files
-      ebwt_base: ebwt
-      offrate: offrate
-      ntoa: ntoa
-      noref: noref
-      ftabchars: ftabchars
-      threads: threads
-    out: [index_files, console_output]
-
   preprocessing:
     run: per-library.cwl
     scatter: [in_fq, sample_basename, fastp_report_title]
@@ -150,22 +136,15 @@ steps:
   preprocessing-subdirs:
     run: organize-outputs.cwl
     in:
-      bt_build_name: dir_name_bt_build
-      bt_build_indexes: bt_build_optional/index_files
-      bt_build_console: bt_build_optional/console_output
       run_bowtie_build: run_bowtie_build
-
-      fastp_name: dir_name_fastp
-      fastp_cleaned_fastq: preprocessing/fastq_clean
-      fastp_html_report: preprocessing/html_report_file
-      fastp_json_report: preprocessing/json_report_file
-      fastp_console: preprocessing/fastp_console
-
-      collapser_name: dir_name_collapser
-      collapser_uniq: preprocessing/uniq_seqs
-      collapser_low: preprocessing/uniq_seqs_low
-      collapser_console: preprocessing/collapser_console
-    out: [ bt_build_dir, fastp_dir, collapser_dir ]
+      ref_in: reference_genome_files
+      ebwt_base: ebwt
+      offrate: offrate
+      ntoa: ntoa
+      noref: noref
+      ftabchars: ftabchars
+      threads: threads
+    out: [ index_files, console_output ]
 
   bowtie:
     run: ../tools/bowtie.cwl

--- a/tiny/entry.py
+++ b/tiny/entry.py
@@ -57,8 +57,7 @@ def get_args():
         "run": "Processes the provided config file and executes the workflow it specifies.",
         "replot": "Resume pipeline at the Plotter step using the PROCESSED run config provided",
         "recount": "Resume pipeline at the Counter step using the PROCESSED run config provided",
-        "setup-cwl": 'Processes the provided config file and copies workflow files to the current directory',
-        "setup-nextflow": "This subcommand is not yet implemented"
+        "setup-cwl": 'Processes the provided config file and copies workflow files to the current directory'
     }
 
     # Subcommands that require a configuration file argument
@@ -105,9 +104,6 @@ def run(tinyrna_cwl_path: str, config_file: str) -> None:
         # Execute the CWL runner via native Python
         return_code = run_native(config_object, workflow, run_directory, verbosity=loudness)
     else:
-        if config_object['run_parallel']:
-            print("WARNING: parallel execution with cwltool is an experimental feature")
-
         # Use the cwltool CWL runner via command line
         return_code = run_cwltool_subprocess(
             cwl_conf_file, workflow,
@@ -320,18 +316,6 @@ def setup_cwl(tinyrna_cwl_path: str, config_file: str) -> None:
     print("The workflow and files are under: cwl/tools/ and cwl/workflows/")
 
 
-def setup_nextflow(config_file: str) -> None:
-    """This function is not yet implemented
-
-    Args:
-        config_file: The YML run configuration file to be converted for use with Nextflow
-
-    """
-
-    print("Creating nextflow workflow...")
-    print("This command is currently not implemented.")
-
-
 def main():
     """The main routine that determines what type of run to do.
 
@@ -356,8 +340,7 @@ def main():
         "replot": lambda: resume(cwl_path, args.config, "Plotter"),
         "recount": lambda: resume(cwl_path, args.config, "Counter"),
         "setup-cwl": lambda: setup_cwl(cwl_path, args.config),
-        "get-template": lambda: get_template(templates_path),
-        "setup-nextflow": lambda: setup_nextflow(args.config)
+        "get-template": lambda: get_template(templates_path)
     }
 
     command_map[args.command]()

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -34,11 +34,11 @@ class ResumeConfig(ConfigBase, ABC):
 
         self.dt = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         self.entry_inputs = entry_inputs
-        self.steps = steps
+        self.steps = steps + [f"organize_{s}" for s in steps]
 
         self._create_truncated_workflow()
         self._rebuild_entry_inputs()
-        self._add_timestamps()
+        self._add_timestamps(steps)
 
     def check_dir_requirements(self):
         """Ensure that user has invoked this command from within the target run directory"""
@@ -73,8 +73,10 @@ class ResumeConfig(ConfigBase, ABC):
             if step not in self.steps:
                 del wf_steps[step]
 
-        # Remove all WorkflowOutputParameters in preparation for the new
-        wf_outputs.clear()
+        # Remove all unassociated WorkflowOutputParameters
+        for step in list(wf_outputs.keys()):
+            if step[:step.rindex("_out_dir")] not in self.steps:
+                del wf_outputs[step]
 
         # Setup new inputs at the workflow level and entry step
         for param, new_input in self.entry_inputs.items():
@@ -83,32 +85,11 @@ class ResumeConfig(ConfigBase, ABC):
             # Update WorkflowStepInputs (entry step)
             wf_steps[self.steps[0]]['in'][param] = new_input['var']
 
-        # Load the organize-outputs subworkflow so that we may copy relevant steps
-        with open(resource_filename('tiny', 'cwl/workflows/organize-outputs.cwl')) as f:
-            organizer_sub_wf = self.yaml.load(f)
-            self.workflow['requirements'].extend(organizer_sub_wf['requirements'])
-
-        for step in self.steps:
-            # Copy relevant steps from organize-outputs.cwl
-            step_name = f'organize_{step}'
-            context = wf_steps[step_name] = organizer_sub_wf['steps'][step_name]
-            del context['when']
-
-            # Update WorkflowStepInputs
-            context['in']['dir_name'] = f'dir_name_{step}'
-            context['in']['dir_files']['source'] = [f"{step}/{output}" for output in wf_steps[step]['out']]
-
-            # Update WorkflowOutputParameter
-            wf_outputs[f'{step}_out_dir'] = {
-                'type': "Directory",
-                'outputSource': f'{step_name}/subdir'
-            }
-
-    def _add_timestamps(self):
+    def _add_timestamps(self, steps):
         """Differentiates resume-run output subdirs by adding a timestamp to them"""
 
         # Rename output directories with timestamp
-        for subdir in self.steps:
+        for subdir in steps:
             step_dir = "dir_name_" + subdir
             self[step_dir] = self[step_dir] + "_" + self.dt
 

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -154,6 +154,9 @@ class ResumePlotterConfig(ResumeConfig):
         # Build resume config from the previously-processed Run Config
         super().__init__(processed_config, workflow, steps, inputs)
 
+        # Remove the PCA plot input since dge is not a step in this resume workflow
+        self.workflow['steps']['organize_plotter']['in']['dir_files']['source'].remove('dge/pca_plot')
+
     def _rebuild_entry_inputs(self):
         """Set the new path inputs for the Plotter step
 


### PR DESCRIPTION
Pipeline startup times have been reduced from 40-60 seconds down to about 17 seconds on my machine. This is the result of simplifying the routine for creating step output subdirectories. To be honest I still can't fathom why it takes 17 whole seconds to validate the workflow and generate its DAG, let alone FORTY TO SIXTY, but... that's somebody else's kitchen.

The design of make-subdir.cwl is vastly better than it was before.

References to Nextflow have been removed from entry.py. This hasn't been a priority or even talked about for months. As far as the associated argparse entry goes, this was essentially just adding an item to the helpstring that we aren't planning to provide anytime soon.

Closes #112 