### PR TITLE
STDERR capture turned off for our Python steps

### DIFF
--- a/tiny/cwl/tools/tiny-collapse.cwl
+++ b/tiny/cwl/tools/tiny-collapse.cwl
@@ -5,7 +5,6 @@ class: CommandLineTool
 
 baseCommand: tiny-collapse
 stdout: $(inputs.input_file.basename + "_console_output.log")
-stderr: $(inputs.input_file.basename + "_console_output.log")
 
 inputs:
   # Fastq files

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -14,7 +14,6 @@ requirements:
 
 baseCommand: tiny-count
 stdout: console_output.log
-stderr: console_output.log
 
 inputs:
   samples_csv:

--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -5,7 +5,6 @@ class: CommandLineTool
 
 baseCommand: tiny-plot
 stdout: console_output.log
-stderr: console_output.log
 
 inputs:
   norm_counts:


### PR DESCRIPTION
While it would be nice to be able to recover captured STDOUT and STDERR from a pipeline step that fails, cwltool simply doesn't offer a complete solution for this (see https://github.com/common-workflow-language/cwltool/issues/1434 )

Instead we have to supply additional flags to tell the runner to leave outputs in the temporary staging directory, and then infer where these incomplete outputs are among many temporary directories with random names created by cwltool.

Until a better solution is found, STDERR capture will be turned off for our Python utilities so that we can help users diagnose issues.