### PR TITLE
Plotter: "unknown" classes in DGE-class scatterplots, title font size change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@
 - The outdated and unclear description of the Features Sheet has been corrected
 - Resource link for WS279 added to TUTORIAL.md
 - Conda installation files now reside in their own top-level directory
+- Bugfix: DGE-class scatter plots now show `Class=unknown` groups by default
+- Plot stylesheet changed to match title font size with axes labels
 - CHANGELOG.md created 

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -220,7 +220,7 @@ def load_dge_tables(comparisons: list) -> pd.DataFrame:
     return de_table
 
 
-def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unknown=False, pval=0.05):
+def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unknown=True, pval=0.05):
     """Creates PDFs of all pairwise comparison scatter plots from a count table.
     Can highlight classes and/or differentially expressed genes as different colors.
 

--- a/tiny/templates/tinyrna-light.mplstyle
+++ b/tiny/templates/tinyrna-light.mplstyle
@@ -32,7 +32,7 @@ ytick.labelsize: 16
 
 #### Axes basics ####
 axes.labelsize: 16
-axes.titlesize: 22
+axes.titlesize: 16
 axes.facecolor: white
 axes.edgecolor: 333333
 axes.linewidth: 1


### PR DESCRIPTION
- Minor bugfix for the DGE-class scatter plot which was omitting Class=unknown groups by default.
- Changed axes title font size to match the axis and tick labels.