### PR TITLE
Bugfix: floating point arithmetic error causing improper omission of "unassigned" category in class_charts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,3 +35,4 @@ jobs:
           python -m unittest unit_tests_counter
           python -m unittest unit_tests_features
           python -m unittest unit_tests_hts_parsing
+          python -m unittest unit_tests_plotter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 12/8/2021
 - Experiments that do not define a control condition no longer cause the DGE step to crash.
 - The calculation of the "unassigned" proportion has been corrected for class_charts
-- Percentages shown on class_charts now round to 2 decimal places. A floating point arithmetic error has been addressed which caused the "unassigned" category to not be displayed when all other proportions sum to 99%.
+- Percentages shown on class_charts now round to 2 decimal places. A floating point arithmetic error has been addressed which caused the "unassigned" category to not be displayed when all other proportions sum to 99.99%.
 
 ### 11/30/2021
 - Temporary files are now removed when `tiny {run|recount|replot}` commands finish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 12/8/2021
+- Experiments that do not define a control condition no longer cause the DGE step to crash.
+- The calculation of the "unassigned" proportion has been corrected for class_charts
+- Percentages shown on class_charts now round to 2 decimal places. A floating point arithmetic error has been addressed which caused the "unassigned" category to not be displayed when all other proportions sum to 99%.
+
 ### 11/30/2021
 - Temporary files are now removed when `tiny {run|recount|replot}` commands finish.
 - The setup script now allows a custom environment name to be passed as a command line argument. It also checks to make sure it is not running in the target environment.

--- a/tests/unit_tests_plotter.py
+++ b/tests/unit_tests_plotter.py
@@ -1,0 +1,109 @@
+import sys
+import unittest
+from unittest.mock import patch, call
+
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from pkg_resources import resource_filename
+
+import tiny.rna.plotter as plotter
+import tiny.rna.plotterlib as lib
+
+class MyTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stylesheet = resource_filename('tiny', 'templates/tinyrna-light.mplstyle')
+
+    """Are class counts properly calculated?"""
+
+    def test_class_counts(self):
+        """If a feature has multiple associated classes, its counts should
+        be divided by the number of classes before being summed."""
+
+        # Each feature contributes a single count to its listed classes
+        counts = {'feat1': ['wago', 1, 1, 1],
+                  'feat2': ['csr,wago', 2, 2, 2],
+                  'feat3': ['wago,csr,other', 3, 3, 3]}
+        raw_counts_df = pd.DataFrame.from_dict(counts, orient='index',
+                        columns=['Feature Class', 'lib1', 'lib2', 'lib3'])
+
+        actual = plotter.get_class_counts(raw_counts_df)
+        expected = pd.DataFrame.from_dict(
+                    {'other': [1.0, 1.0, 1.0],
+                     'csr':   [2.0, 2.0, 2.0],
+                     'wago':  [3.0, 3.0, 3.0]},
+                    orient='index', columns=['lib1', 'lib2', 'lib3'])
+
+        assert_frame_equal(actual, expected, check_like=True)
+
+    """Are class proportion percentages calculated properly?"""
+
+    def test_class_chart_table_percentage(self):
+        class_s = pd.Series({'csr': 75, 'wago': 50, 'other': 25})
+
+        with patch.object(lib.plt.Axes, 'table') as table:
+            plib = lib.plotterlib(self.stylesheet)
+            plib.class_pie_barh(class_s, 100)
+
+        expected = np.array([
+            ['csr', '75.00%'],
+            ['wago', '50.00%'],
+            ['other', '25.00%']
+        ], dtype=object)
+
+        np.testing.assert_array_equal(table.call_args[1]['cellText'], expected)
+
+    """Do class proportion percentages have the correct scale?"""
+
+    def test_class_chart_table_percentage_scale(self):
+        class_s = pd.Series({'csr': 1})
+
+        with patch.object(lib.plt.Axes, 'table') as table:
+            plib = lib.plotterlib(self.stylesheet)
+            plib.class_pie_barh(class_s, 3)
+
+        expected = np.array([
+            ['csr', '33.33%'],
+            ['Unassigned', '66.67%']
+        ], dtype=object)
+
+        np.testing.assert_array_equal(table.call_args[1]['cellText'], expected)
+
+    """Do class proportion percentages display "Unassigned" at the correct threshold?"""
+
+    def test_class_chart_table_percentage_unassigned(self):
+        """This problem becomes very interesting when you consider floating point precision.
+        Percentage values are rounded according to the scale for simplicity, which we assume
+        to be 2 for percentages (4 for decimal). With this in mind the threshold value for
+        "Unassigned" is the rounding threshold at scale + 1"""
+
+        class_count = 1
+        class_s = pd.Series({'csr': class_count})
+
+        # Value here refers to the decimal value of the "Unassigned" category
+        above_thresh_value = 0.00005
+        above_thresh_total = class_count / (1 - above_thresh_value)
+        below_thresh_value = 0.00004
+        below_thresh_total = class_count / (1 - below_thresh_value)
+
+        with patch.object(lib.plt.Axes, 'table') as table:
+            plib = lib.plotterlib(self.stylesheet)
+            plib.class_pie_barh(class_s, above_thresh_total)
+            plib.class_pie_barh(class_s, below_thresh_total)
+
+        expected_above_thresh = np.array([
+            ['csr', '99.99%'],
+            ['Unassigned', '0.01%']
+        ])
+
+        expected_below_thresh = np.array([
+            ['csr', '100.00%']
+        ])
+
+        np.testing.assert_array_equal(table.call_args_list[0][1]['cellText'], expected_above_thresh)
+        np.testing.assert_array_equal(table.call_args_list[1][1]['cellText'], expected_below_thresh)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -141,18 +141,19 @@ class plotterlib:
         fig, ax = self.reuse_subplot("class_chart")
 
         # Convert reads to proportion
-        class_prop = (class_s / mapped_reads).rename('Proportion')
+        scale += 2  # Convert percentage scale to decimal scale
+        class_prop = (class_s / mapped_reads).round(scale).rename('Proportion')
 
         # Determine whether an unassigned category should be displayed
-        unassigned = 1 - class_prop.sum()
-        if unassigned >= 10 ** (-1 * (scale + 2)): class_prop['Unassigned'] = unassigned
+        unassigned = round(1 - class_prop.sum(), scale)
+        if unassigned >= round(10 ** (-1 * scale), scale): class_prop['Unassigned'] = unassigned
 
         # Plot pie and barh on separate axes
         self.class_pie(class_prop, ax=ax[0], labels=None, **kwargs)
         self.class_barh(class_prop, ax=ax[1], legend=None, title=None, ylabel=None, **kwargs)
 
         # Add a table to the pie chart
-        table_s = class_prop.map(lambda x: f"{x*100:.{scale}f}%").reset_index()
+        table_s = class_prop.map(lambda x: f"{x*100:.{scale-2}f}%").reset_index()
         table = ax[0].table(cellText=table_s.values, loc='bottom')
         table.auto_set_column_width(col=[0, 1])
 


### PR DESCRIPTION
The "unassigned" category in class charts will currently fail to be included when the proportion is very small. In these cases the other classes will sum to 99.99%. I've taken care to ensure that the solution adapts to the scale incase we want to increase or decrease the decimal precision of the table percentages.

Unit tests have been added for this subject and for the calculation of class counts for features with multiple associated classes.