### PR TITLE
Bugfix: strict interval matching fixed

### DIFF
--- a/tests/unit_test_helpers.py
+++ b/tests/unit_test_helpers.py
@@ -11,6 +11,13 @@ import sys
 import io
 import os
 
+rules_template = [{'Identity': ("Name", "N/A"),
+                   'Strand': "both",
+                   'Hierarchy': 0,
+                   'nt5end': "all",
+                   'Length': "all",   # A string is expected by FeatureSelector due to support for lists and ranges
+                   'Strict': True}]
+
 
 def get_dir_tree(root_path: str) -> dict:
     """Returns a nested dictionary representation of a given directory tree.
@@ -75,6 +82,19 @@ def get_dir_checksum_tree(root_path: str) -> dict:
             context['files'].append((file, hashlib.md5(file_content).hexdigest()))
 
     return dir_tree
+
+
+def make_parsed_sam_record(name="0_count=1", seq="CAAGACAGAGCTTCACCGTTC", chrom='I', start=15064570, strand='+'):
+    return {
+        "name": name,
+        "len": len(seq),
+        "seq": seq,
+        "nt5": seq[0] if strand == '+' else seq[-1].translate(complement),
+        "chrom": chrom,
+        "start": start,
+        "end": start + len(seq),
+        "strand": strand
+    }
 
 
 def make_single_sam(name="read_id", strand="+", chrom="I", start=15064570, seq="CAAGACAGAGCTTCACCGTTC"):

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -25,21 +25,22 @@ class CounterTests(unittest.TestCase):
 
         self.strand = {'sense': tuple('+'), 'antisense': tuple('-'), 'both': ('+', '-')}
 
-        # ID, Key, Value, Hierarchy, Strand, nt5, Length, Match, Source
+        # Configuration.CSVReader field names for Features Sheet:
+        # Key, Value, Name, Hierarchy, Strand, nt5end, Length, Strict, Source
         self.csv_feat_row_dict = {'Key': "Class", 'Value': "CSR", 'Name': "Alias", 'Hierarchy': "1",
-                                  'Strand': "antisense", 'nt5': '"C,G,U"', 'Length': "all", 'Match': "Partial",
+                                  'Strand': "antisense", 'nt5end': '"C,G,U"', 'Length': "all", 'Strict': "Partial",
                                   'Source': "./testdata/cel_ws279/c_elegans_WS279_chr1.gff3"}
-                                   # nt5 needs to be double quoted since it contains commas
+                                  # nt5 needs to be double quoted since it contains commas
 
         # Identity, Hierarchy, Strand, nt5, Length, Strict
-        row = self.csv_feat_row_dict
+        _row = self.csv_feat_row_dict
         self.feat_rule = [{
-            'Identity': (row['Key'], row['Value']),
-            'Hierarchy': int(row['Hierarchy']),
-            'Strand': row['Strand'],
-            'nt5end': row['nt5'].upper().translate({ord('U'): 'T'}).replace('"', ''),  # Undo csv comma quoting
-            'Length': row['Length'],
-            'Strict': row['Match'] == 'Full'
+            'Identity': (_row['Key'], _row['Value']),
+            'Hierarchy': int(_row['Hierarchy']),
+            'Strand': _row['Strand'],
+            'nt5end': _row['nt5end'].upper().translate({ord('U'): 'T'}).replace('"', ''),  # Undo csv comma quoting
+            'Length': _row['Length'],
+            'Strict': _row['Strict'] == 'Full'
         }]
 
         self.csv_samp_row_dict = {'file': "test_file.fastq", 'group': "test_group", 'rep': "0"}
@@ -213,7 +214,7 @@ class CounterTests(unittest.TestCase):
 
     def test_load_config_rna_to_cDNA(self):
         row = self.csv_feat_row_dict.copy()
-        row['nt5'] = 'U'
+        row['nt5end'] = 'U'
         csv = self.csv("features.csv", [row.values()])
 
         with patch('tiny.rna.configuration.open', mock_open(read_data=csv)):


### PR DESCRIPTION
Closes #148 

Additionally, in some cases subintervals of discontinuous features can wind up being defined adjacent to each other after processing. This happens when the adjacent intervals are defined under unique feature IDs but share the same root parent; this results in two side-by-side intervals with the root parent's feature ID. 

`StepVector.get_steps(merge_values=True)` will remedy this by merging the adjacent intervals but there are two issues with this:
1. Merging is performed by value. Now that start/stop coordinates are included in the feature record tuple, which is what is stored in the StepVector, the adjacent tuples will contain their subinterval coordinates and will therefore be "unique" and thus left unmerged.
2. On-the-fly merging happens on every `interval -> overlapping features` lookup. It isn't particularly expensive but it's unnecessary work.

Now, these adjacent subintervals are merged just once before storing them in the StepVector so that on-the-fly merging is no longer necessary.