### PR TITLE
Bugfix: unique sequence off-by-one count corrected in summary_stats.csv reports

### DIFF
--- a/tests/unit_tests_statistics.py
+++ b/tests/unit_tests_statistics.py
@@ -1,9 +1,45 @@
+import sys
 import unittest
+from unittest.mock import patch, mock_open, create_autospec
+
+from tiny.rna.counter.statistics import LibraryStats, SummaryStats
 
 
 class MyTestCase(unittest.TestCase):
     def test_something(self):
         self.assertEqual(True, False)
+
+    def create_mock_libstats(self, lib=None):
+        library = {
+            'Name': 'mock_name',
+            'File': 'mock_file',
+            'collapsed': 'mock_file',
+            'fastp_log': 'mock_file'
+        }
+
+        if lib: library.update(lib)
+        libstat_obj = LibraryStats()
+        libstat_obj.assign_library(library)
+        return libstat_obj
+
+
+    def test_collapser_stat(self):
+        # Collapser's FASTA headers are structured as (zero-based) INDEX_count=COUNT.
+        # Headers are sorted by index, so the index of the last header is the count
+        # of unique sequences in the quality-filtered sample + 1
+
+        fasta = './testdata/collapser/Lib303_thresh_0_collapsed.fa'
+        mock_libstats = self.create_mock_libstats({'collapsed': fasta})
+        expected_count = 9631
+
+        with patch('tiny.rna.counter.statistics.SummaryStats') as mock:
+            instance = mock.return_value
+            uniq_seq_count = SummaryStats.get_collapser_stats(instance, mock_libstats)
+
+        with open(fasta) as f: sanity_check = len(f.readlines())/2
+
+        self.assertEqual(uniq_seq_count, expected_count)
+        self.assertEqual(sanity_check, expected_count)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests_statistics.py
+++ b/tests/unit_tests_statistics.py
@@ -25,8 +25,8 @@ class MyTestCase(unittest.TestCase):
 
     def test_collapser_stat(self):
         # Collapser's FASTA headers are structured as (zero-based) INDEX_count=COUNT.
-        # Headers are sorted by index, so the index of the last header is the count
-        # of unique sequences in the quality-filtered sample + 1
+        # Headers are sorted by index, so the index in the last header is the (count - 1)
+        # of unique sequences in the quality-filtered sample
 
         fasta = './testdata/collapser/Lib303_thresh_0_collapsed.fa'
         mock_libstats = self.create_mock_libstats({'collapsed': fasta})

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -297,8 +297,7 @@ class SummaryStats:
             # Zero-based count
             return int(count) + 1
         except ValueError:
-            self.warnings.append("Unable to parse collapsed fasta associated with for Summary Statistics.")
-            self.warnings.append("Associated file: " + other.library['File'])
+            self.warnings.append(f"Unable to parse {other.library['collapsed']} for Summary Statistics.")
             return None
 
     @staticmethod


### PR DESCRIPTION
Closes #152 

The procedure for determining this count from collapsed FASTA files has been improved. The old approach would fail if, for some reason, the length of the last sequence was over `75 - (log(COUNT) + log(INDEX) + 11)`. MMapped files support in-memory rfind without guessing at the final record's length, so it is much more succinct and reliable to use them instead.