### PR TITLE
Counter: strandless lookup optimization

### DIFF
--- a/tests/unit_tests_features.py
+++ b/tests/unit_tests_features.py
@@ -83,7 +83,7 @@ class FeaturesTests(unittest.TestCase):
     """Does assign_features correctly handle alignments with zero feature matches?"""
 
     def test_assign_features_no_match(self):
-        htsgas = HTSeq.GenomicArrayOfSets("auto", stranded=True)
+        htsgas = HTSeq.GenomicArrayOfSets("auto", stranded=False)
         Features.chrom_vectors = htsgas.chrom_vectors
         chrom, strand = "I", "+"
 
@@ -109,7 +109,7 @@ class FeaturesTests(unittest.TestCase):
     """Does assign_features return features that overlap the query interval by a single base?"""
 
     def test_assign_features_single_base_overlap(self):
-        htsgas = HTSeq.GenomicArrayOfSets("auto", stranded=True)
+        htsgas = HTSeq.GenomicArrayOfSets("auto", stranded=False)
         Features.chrom_vectors = htsgas.chrom_vectors
         chrom, strand = "I", "+"
         

--- a/tests/unit_tests_features.py
+++ b/tests/unit_tests_features.py
@@ -172,7 +172,7 @@ class FeaturesTests(unittest.TestCase):
         chrom, strand, start, stop = "I", "+", 5, 10
         rules = [dict(rules_template[0], Strict=strict, Identity=('N/A', 'N/A'), nt5end='all', Length='all')]
 
-        # Feature with coordinates 5..10, matching rule 0 with hierarchy 0 and strict interval
+        # Feature with coordinates 5..10, matching rule 0 with hierarchy 0 and strict interval = True
         feat = {("Strict Overlap", start, stop, strand, ((0, 0, strict),))}
 
         aln_base = {'seq': 'ATGC', 'chrom': chrom, 'strand': strand}
@@ -206,7 +206,7 @@ class FeaturesTests(unittest.TestCase):
         chrom, strand, start, stop = "I", "+", 5, 10
         rules = [dict(rules_template[0], Strict=strict, Identity=('N/A', 'N/A'), nt5end='all', Length='all')]
 
-        # Feature with coordinates 5..10, matching rule 0 with hierarchy 0 and strict interval
+        # Feature with coordinates 5..10, matching rule 0 with hierarchy 0 and strict interval = False
         feat = {("Partial Overlap", start, stop, strand, ((0, 0, strict),))}
 
         aln_base = {'seq': 'ATGC', 'chrom': chrom, 'strand': strand}

--- a/tests/unit_tests_features.py
+++ b/tests/unit_tests_features.py
@@ -183,12 +183,13 @@ class FeaturesTests(unittest.TestCase):
         aln_contained_hi = make_parsed_sam_record(**dict(aln_base, start=start + 1, name="contained"))
 
         """
+        aln:                  |ATGC|
         feat:               5 |-----| 10
-        aln_spill_lo:      4 |----| 8
-        aln_spill_hi:         7 |----| 11
-        aln_contained:        7 |-| 8       # Fully contained
-        aln_contained_lo:   5 |----| 9      # Shared start position
-        aln_contained_hi:    6 |----| 10    # Shared end position
+        aln_spill_lo:      4 |ATGC| 8
+        aln_spill_hi:         7 |ATGC| 11
+        aln_contained:        7 |N| 8       # Fully contained
+        aln_contained_lo:   5 |ATGC| 9      # Shared start position
+        aln_contained_hi:    6 |ATGC| 10    # Shared end position
         """
 
         fs = FeatureSelector(rules, LibraryStats())
@@ -215,11 +216,12 @@ class FeaturesTests(unittest.TestCase):
         aln_contained_hi = make_parsed_sam_record(**dict(aln_base, start=start + 1, name="contained"))
 
         """
+        aln:                  |ATGC|
         feat:               5 |-----| 10
-        aln_spill_lo:      4 |----| 8
-        aln_spill_hi:         7 |----| 11
-        aln_contained_lo:   5 |----| 9      Shared start position
-        aln_contained_hi:    6 |----| 10    Shared end position
+        aln_spill_lo:      4 |ATGC| 8
+        aln_spill_hi:         7 |ATGC| 11
+        aln_contained_lo:   5 |ATGC| 9      Shared start position
+        aln_contained_hi:    6 |ATGC| 10    Shared end position
         """
 
         fs = FeatureSelector(rules, LibraryStats())

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -256,7 +256,7 @@ class MyTestCase(unittest.TestCase):
 
         feats, _, _ = ReferenceTables(feature_source, feature_selector, **kwargs).get()
 
-        actual_idents = list(feats.chrom_vectors['I']['-'].array.get_steps(values_only=True))
+        actual_idents = list(feats.chrom_vectors['I']['.'].array.get_steps(values_only=True))
         for act_attr, exp_attr in zip(actual_idents, expected_matches):
             self.assertEqual(act_attr, exp_attr)
 
@@ -347,7 +347,7 @@ class MyTestCase(unittest.TestCase):
 
         feats, _, _ = ReferenceTables(feature_source, feature_selector, **rt_kwargs).get()
 
-        for act, exp in zip(feats.chrom_vectors["I"]["-"].array.get_steps(values_only=True), expected):
+        for act, exp in zip(feats.chrom_vectors["I"]["."].array.get_steps(values_only=True), expected):
             # For this test we are only interested in the match tuples for each feature
             self.assertEqual(act, exp)
 
@@ -375,7 +375,7 @@ class MyTestCase(unittest.TestCase):
 
         feats, _, _, = ReferenceTables(feature_source, feature_selector, **kwargs).get()
 
-        for act, exp in zip(feats.chrom_vectors["I"]["-"].array.get_steps(values_only=True), expected):
+        for act, exp in zip(feats.chrom_vectors["I"]["."].array.get_steps(values_only=True), expected):
             self.assertEqual(act, exp)
 
     """Does ReferenceTables.get() properly handle source filters for discontinuous features?"""
@@ -402,7 +402,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(rt.parents, exp_parents)
         self.assertEqual(rt.filtered, exp_filtered)
         self.assertEqual(classes, exp_classes)
-        self.assertEqual(list(feats.chrom_vectors['I']['-'].array.get_steps(values_only=True)), exp_feats)
+        self.assertEqual(list(feats.chrom_vectors['I']['.'].array.get_steps(values_only=True)), exp_feats)
         self.clear_filters()
 
     """Does ReferenceTables.get() properly handle type filters for discontinuous features?"""
@@ -427,7 +427,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(rt.intervals, exp_intervals)
         self.assertEqual(rt.parents, exp_parents)
         self.assertEqual(rt.filtered, exp_filtered)
-        self.assertEqual(list(feats.chrom_vectors['I']['-'].array.get_steps(values_only=True)), exp_feats)
+        self.assertEqual(list(feats.chrom_vectors['I']['.'].array.get_steps(values_only=True)), exp_feats)
         self.clear_filters()
 
     """Does ReferenceTables.get() properly handle both source and type filters for discontinuous features?"""
@@ -445,7 +445,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(rt.parents, {'ParentWithGrandparent': 'GrandParent', 'Child1': 'ParentWithGrandparent', 'Child2': 'Parent2'})
         self.assertEqual(list(classes.keys()), ['GrandParent', 'Parent2', 'Sibling'])
         self.assertEqual(list(alias.keys()), ['GrandParent', 'Parent2', 'Sibling'])
-        self.assertEqual(len(list(feats.chrom_vectors['I']['-'].array.get_steps(values_only=True))), 9)
+        self.assertEqual(len(list(feats.chrom_vectors['I']['.'].array.get_steps(values_only=True))), 9)
         self.clear_filters()
 
     def clear_filters(self):

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -54,11 +54,10 @@ class FeatureCounter:
 
         try:
             # Resolve features from alignment interval on both strands, regardless of alignment strand
-            feat_matches = feat_matches.union(*(
-                    match for strand in BOTH_STRANDS for match in
-                    (Features.chrom_vectors[al['chrom']][strand]  # GenomicArrayOfSets -> ChromVector
-                             .array[al['start']:al['end']]        # ChromVector -> StepVector
-                             .get_steps(values_only=True))        # StepVector -> (iv_start, iv_end, {features})
+            feat_matches = feat_matches.union(*(match for match in
+                    (Features.chrom_vectors[al['chrom']]['.']       # GenomicArrayOfSets -> ChromVector
+                             .array[al['start']:al['end']]          # ChromVector -> StepVector
+                             .get_steps(values_only=True))          # StepVector -> (iv_start, iv_end, {features})
                     # If an alignment does not map to a feature, an empty set is returned
                     if len(match) != 0))
         except KeyError as ke:

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -53,11 +53,10 @@ class FeatureCounter:
         feat_matches, assignment = set(), set()
 
         try:
-            # Resolve features from alignment interval on both strands, regardless of alignment strand
             feat_matches = feat_matches.union(*(match for match in
                     (Features.chrom_vectors[al['chrom']]['.']       # GenomicArrayOfSets -> ChromVector
                              .array[al['start']:al['end']]          # ChromVector -> StepVector
-                             .get_steps(values_only=True))          # StepVector -> (iv_start, iv_end, {features})
+                             .get_steps(values_only=True))          # StepVector -> {features}
                     # If an alignment does not map to a feature, an empty set is returned
                     if len(match) != 0))
         except KeyError as ke:

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -183,7 +183,7 @@ class ReferenceTables:
         self._set_filters(**kwargs)
         self.gff_files = gff_files
 
-        self.feats = HTSeq.GenomicArrayOfSets("auto", stranded=True)
+        self.feats = HTSeq.GenomicArrayOfSets("auto", stranded=False)
         self.parents, self.filtered = {}, set()
         self.intervals = defaultdict(list)
         self.matches = defaultdict(set)


### PR DESCRIPTION
Now that strand information is embedded in feature record tuples, it is no longer necessary to maintain a stranded GenomicArray for storing features. This also means that FeatureCounter.assign_features() no longer needs to perform two lookups for each alignment (one for each strand). This 50% reduction in calls to StepVector.get_steps() translates to a decent reduction in runtime.

The dataset I have been using for casual benchmarking:
- 10 SAM files with a total of 57,281,310 alignments (3.09 gb)
- A reduced WS230 GFF3 file with 21,808 features
- A permissive ruleset with 5 rules of equal hierarchy:

|Select for...|with value...|Alias by...|Hierarchy|Strand (sense/antisense/both)|5' End Nucleotide|Length|Match  |
|-------------|-------------|-----------|---------|-----------------------------|-----------------|------|-------|
|Class        |rRNA         |ID         |1        |Both                         |all              |all   |Partial|
|Class        |miRNA        |ID         |1        |Both                         |all              |all   |Partial|
|Class        |piRNA        |ID         |1        |Both                         |T                |all   |Partial|
|Class        |csr          |ID         |1        |Both                         |all              |all   |Partial|
|Class        |wago         |ID         |1        |Both                         |all              |all   |Partial|

With the above configuration, this PR results in a consistent **30+% reduction in runtime**. 
On my machine the entire 3.09 gb analysis completes in **just under 1 minute**
