### PR TITLE
Counter: 'Reads Assigned to Single/Multiple Feature(s)' semantics changed

### DIFF
--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -82,7 +82,7 @@ class FeatureCounter:
             # For each alignment of the given sequence...
             for alignment in bundle:
                 hits, n_candidates = self.assign_features(alignment)
-                self.stats.count_bundle_alignments(bstat, alignment, hits, n_candidates)
+                self.stats.count_bundle_assignments(bstat, alignment, hits, n_candidates)
 
             self.stats.finalize_bundle(bstat)
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -47,7 +47,8 @@ class LibraryStats:
             'loci_count': loci_counts,
             'read_count': read_counts,
             'corr_count': corr_counts,
-            'assignments': list(),
+            'assigned_feats': set(),
+            'assigned_reads': 0,
             'mapping_stat':
                 "Assigned Single-Mapping Reads"
                 if loci_counts == 1 else
@@ -66,7 +67,7 @@ class LibraryStats:
     def no_norm(self, count, _):
         return count
 
-    def count_bundle_alignments(self, bundle, aln: dict, assignments: set, n_candidates: int) -> None:
+    def count_bundle_assignments(self, bundle: dict, aln: dict, assignments: set, n_candidates: int) -> None:
         """Called for each alignment for each read"""
 
         assigned_count = len(assignments)
@@ -79,29 +80,31 @@ class LibraryStats:
             self.library_stats[bundle['mapping_stat']] += corr_count
 
             feature_corrected_count = self.normalize_count_by(corr_count, assigned_count)
+            bundle['assigned_feats'] |= assignments
+            bundle['assigned_reads'] += corr_count
 
             for feat in assignments:
-                bundle['assignments'].append(feat)
                 self.feat_counts[feat] += feature_corrected_count
 
         if self.diags is not None:
             self.diags.record_diagnostics(assignments, n_candidates, aln, bundle)
             self.diags.record_alignment_details(aln, bundle, assignments)
 
-    def finalize_bundle(self, bundle) -> None:
+    def finalize_bundle(self, bundle: dict) -> None:
         """Called at the conclusion of processing each multiple-alignment bundle"""
 
-        assignment_count = len(bundle['assignments'])
+        assignment_count = len(bundle['assigned_feats'])
 
         if assignment_count == 0:
             self.library_stats['Total Unassigned Sequences'] += 1
-        elif assignment_count == 1:
-            self.library_stats['Reads Assigned to Single Feature'] += bundle['read_count']
         else:
             self.library_stats['Total Assigned Sequences'] += 1
-            self.library_stats['Reads Assigned to Multiple Features'] += bundle['read_count']
-            self.library_stats['Sequences Assigned to Single Feature'] += 1 * (assignment_count == 1)
-            self.library_stats['Sequences Assigned to Multiple Features'] += 1 * (assignment_count > 1)
+            if assignment_count == 1:
+                self.library_stats['Reads Assigned to Single Feature'] += bundle['assigned_reads']
+                self.library_stats['Sequences Assigned to Single Feature'] += 1
+            else:
+                self.library_stats['Reads Assigned to Multiple Features'] += bundle['assigned_reads']
+                self.library_stats['Sequences Assigned to Multiple Features'] += 1
 
 
 class SummaryStats:

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -74,10 +74,6 @@ class LibraryStats:
 
         if assigned_count == 0:
             self.library_stats['Total Unassigned Reads'] += corr_count
-        if assigned_count == 1:
-            self.library_stats['Reads Assigned to Single Feature'] += corr_count
-        if assigned_count > 1:
-            self.library_stats['Reads Assigned to Multiple Features'] += corr_count
         if assigned_count > 0:
             self.library_stats['Total Assigned Reads'] += corr_count
             self.library_stats[bundle['mapping_stat']] += corr_count
@@ -99,8 +95,11 @@ class LibraryStats:
 
         if assignment_count == 0:
             self.library_stats['Total Unassigned Sequences'] += 1
+        elif assignment_count == 1:
+            self.library_stats['Reads Assigned to Single Feature'] += bundle['read_count']
         else:
             self.library_stats['Total Assigned Sequences'] += 1
+            self.library_stats['Reads Assigned to Multiple Features'] += bundle['read_count']
             self.library_stats['Sequences Assigned to Single Feature'] += 1 * (assignment_count == 1)
             self.library_stats['Sequences Assigned to Multiple Features'] += 1 * (assignment_count > 1)
 


### PR DESCRIPTION
Closes #156 

This PR also includes the following additional bugfix (now updated in the issue-158 description):
Previously the determination for "Single/Multiple Features" counted the assignment of the same feature at multiple loci as a "multiple feature" assignment. This is also true for "Sequences Assigned to _". That means for sequences with one unique feature assignment at multiple loci, their counts were incorrectly added to the "multiple feature" stat. This is no longer the case; the determination for "single/multiple" now only considers the total UNIQUE features assigned to each sequence.