### PR TITLE
CWL: command line options added for decollapsed SAM, vectorized scatter points

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -222,6 +222,9 @@ counter_all_features: False
 ##-- If True: counts won't be normalized by genomic hits and (selected) feature count --##
 counter_no_normalize: False
 
+##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
+counter_decollapse: False
+
 ##-- Only parse GFF lines that match these values on column 2. [] is wildcard --##
 counter_source_filter: []
 

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -222,6 +222,9 @@ counter_all_features: False
 ##-- If True: counts won't be normalized by genomic hits and (selected) feature count --##
 counter_no_normalize: False
 
+##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
+counter_decollapse: False
+
 ##-- Only parse GFF lines that match these values on column 2. [] is wildcard --##
 counter_source_filter: []
 

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -48,6 +48,11 @@ inputs:
     inputBinding:
       prefix: -nn
 
+  decollapse:
+    type: boolean?
+    inputBinding:
+      prefix: -dc
+
   all_features:
     type: boolean?
     inputBinding:
@@ -101,6 +106,11 @@ outputs:
     type: File
     outputBinding:
       glob: $(inputs.out_prefix)_summary_stats.csv
+
+  decollapsed_sams:
+    type: File[]?
+    outputBinding:
+      glob: "*_decollapsed.sam"
 
   intermed_out_files:
     type: File[]?

--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -50,6 +50,12 @@ inputs:
       prefix: -s
     doc: "A .mplstyle sheet to use instead of tinyrna default styles"
 
+  vector_scatter:
+    type: boolean?
+    inputBinding:
+      prefix: -v
+    doc: "If provided, scatter plots will have vectorized points (slower)"
+
   out_prefix:
     type: string?
     inputBinding:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -93,6 +93,7 @@ inputs:
 
   # plotter options
   plot_requests: string[]
+  plot_vector_points: boolean?
   plot_style_sheet: File?
   plot_pval: float?
 
@@ -232,6 +233,7 @@ steps:
       style_sheet: plot_style_sheet
       out_prefix: run_name
       plot_requests: plot_requests
+      vector_scatter: plot_vector_points
     out: [plots, console_output]
 
   organize_bt_indexes:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -79,6 +79,7 @@ inputs:
   aligned_seqs: File[]?
   is_pipeline: boolean?
   counter_diags: boolean?
+  counter_decollapse: boolean?
   counter_no_normalize: boolean?
   counter_all_features: boolean?
   counter_type_filter: string[]?
@@ -198,13 +199,14 @@ steps:
       all_features: counter_all_features
       source_filter: counter_source_filter
       no_normalize: counter_no_normalize
+      decollapse: counter_decollapse
       type_filter: counter_type_filter
       is_pipeline: {default: true}
       diagnostics: counter_diags
       fastp_logs: preprocessing/json_report_file
       collapsed_fa: preprocessing/uniq_seqs
     out: [ feature_counts, other_counts, alignment_stats, summary_stats, console_output,
-           intermed_out_files, alignment_diags, selection_diags ]
+           decollapsed_sams, intermed_out_files, alignment_diags, selection_diags ]
 
   dge:
     run: ../tools/tiny-deseq.cwl
@@ -274,7 +276,7 @@ steps:
       dir_files:
         source: [ counter/feature_counts, counter/other_counts, counter/alignment_stats, counter/summary_stats,
                   counter/intermed_out_files, counter/alignment_diags, counter/selection_diags, counter/console_output,
-                  features_csv ]
+                  counter/decollapsed_sams, features_csv ]
       dir_name: dir_name_counter
     out: [ subdir ]
 

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -222,6 +222,9 @@ counter_all_features: False
 ##-- If True: counts won't be normalized by genomic hits and (selected) feature count --##
 counter_no_normalize: False
 
+##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
+counter_decollapse: False
+
 ##-- Only parse GFF lines that match these values on column 2. [] is wildcard --##
 counter_source_filter: []
 


### PR DESCRIPTION
The command line option for Counter's `--decollapse` option has been added to the Run Config files and CWL definitions.

The Run Config key `plot_vector_points` now correctly sets the corresponding command line option during pipeline execution.

Closes #157 