### PR TITLE
Plotter: Log2 subscript character font

### DIFF
--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -190,13 +190,13 @@ def scatter_replicates(count_df: pd.DataFrame, output_prefix: str, samples: dict
     for samp, reps in samples.items():
         for pair in itertools.combinations(reps, 2):
             rscat = aqplt.scatter_simple(count_df.loc[:,pair[0]], count_df.loc[:,pair[1]],
-                                         color='#A1A1A1', alpha=0.5, log_norm=True, rasterized=RASTER)
+                                         color='#B3B3B3', alpha=0.5, log_norm=True, rasterized=RASTER)
             aqplt.set_square_scatter_view_lims(rscat, view_lims)
             aqplt.set_scatter_ticks(rscat)
             rscat.set_title(samp)
             rep1, rep2 = pair[0].split('_rep_')[1], pair[1].split('_rep_')[1]
-            rscat.set_xlabel("Log"+u'\u2082'+" normalized reads in replicate " + rep1)
-            rscat.set_ylabel("Log"+u'\u2082'+" normalized reads in replicate " + rep2)
+            rscat.set_xlabel("Log$_{2}$ normalized reads in replicate " + rep1)
+            rscat.set_ylabel("Log$_{2}$ normalized reads in replicate " + rep2)
             pdf_name = make_filename([output_prefix, samp, 'replicates', rep1, rep2, 'scatter'], ext='.pdf')
             rscat.figure.savefig(pdf_name)
 
@@ -259,8 +259,8 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, *grp_args,
                                           log_norm=True, labels=labels, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
-            sscat.set_xlabel(f"Log"+u'\u2082'+" normalized reads in " + p1)
-            sscat.set_ylabel(f"Log"+u'\u2082'+" normalized reads in " + p2)
+            sscat.set_xlabel("Log$_{2}$ normalized reads in " + p1)
+            sscat.set_ylabel("Log$_{2}$ normalized reads in " + p2)
             pdf_name = make_filename([output_prefix, pair, 'scatter_by_dge_class'], ext='.pdf')
             sscat.figure.savefig(pdf_name)
 
@@ -273,8 +273,8 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, grp_args,
                                           log_norm=True, labels=labels, alpha=0.5, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
-            sscat.set_xlabel("Log"+u'\u2082'+" normalized reads in " + p1)
-            sscat.set_ylabel("Log"+u'\u2082'+" normalized reads in " + p2)
+            sscat.set_xlabel("Log$_{2}$ normalized reads in " + p1)
+            sscat.set_ylabel("Log$_{2}$ normalized reads in " + p2)
             pdf_name = make_filename([output_prefix, pair, 'scatter_by_dge'], ext='.pdf')
             sscat.figure.savefig(pdf_name)
 

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -259,8 +259,8 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, *grp_args,
                                           log_norm=True, labels=labels, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
-            sscat.set_xlabel("Log$_{2}$ normalized reads in " + p1)
-            sscat.set_ylabel("Log$_{2}$ normalized reads in " + p2)
+            sscat.set_xlabel(f"Log"+u'\u2082'+" normalized reads in " + p1)
+            sscat.set_ylabel(f"Log"+u'\u2082'+" normalized reads in " + p2)
             pdf_name = make_filename([output_prefix, pair, 'scatter_by_dge_class'], ext='.pdf')
             sscat.figure.savefig(pdf_name)
 

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -190,13 +190,13 @@ def scatter_replicates(count_df: pd.DataFrame, output_prefix: str, samples: dict
     for samp, reps in samples.items():
         for pair in itertools.combinations(reps, 2):
             rscat = aqplt.scatter_simple(count_df.loc[:,pair[0]], count_df.loc[:,pair[1]],
-                                         color='#B3B3B3', alpha=0.5, log_norm=True, rasterized=RASTER)
+                                         color='#A1A1A1', alpha=0.5, log_norm=True, rasterized=RASTER)
             aqplt.set_square_scatter_view_lims(rscat, view_lims)
             aqplt.set_scatter_ticks(rscat)
             rscat.set_title(samp)
             rep1, rep2 = pair[0].split('_rep_')[1], pair[1].split('_rep_')[1]
-            rscat.set_xlabel('Log$_{2}$ normalized reads in replicate ' + rep1)
-            rscat.set_ylabel('Log$_{2}$ normalized reads in replicate ' + rep2)
+            rscat.set_xlabel("Log"+u'\u2082'+" normalized reads in replicate " + rep1)
+            rscat.set_ylabel("Log"+u'\u2082'+" normalized reads in replicate " + rep2)
             pdf_name = make_filename([output_prefix, samp, 'replicates', rep1, rep2, 'scatter'], ext='.pdf')
             rscat.figure.savefig(pdf_name)
 
@@ -273,8 +273,8 @@ def scatter_dges(count_df, dges, output_prefix, viewLims, classes=None, show_unk
             sscat = aqplt.scatter_grouped(count_df.loc[:,p1], count_df.loc[:,p2], viewLims, grp_args,
                                           log_norm=True, labels=labels, alpha=0.5, rasterized=RASTER)
             sscat.set_title('%s vs %s' % (p1, p2))
-            sscat.set_xlabel("Log$_{2}$ normalized reads in " + p1)
-            sscat.set_ylabel("Log$_{2}$ normalized reads in " + p2)
+            sscat.set_xlabel("Log"+u'\u2082'+" normalized reads in " + p1)
+            sscat.set_ylabel("Log"+u'\u2082'+" normalized reads in " + p2)
             pdf_name = make_filename([output_prefix, pair, 'scatter_by_dge'], ext='.pdf')
             sscat.figure.savefig(pdf_name)
 

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -247,7 +247,7 @@ class plotterlib:
                                         log_norm=log_norm, color=next(colors), **kwargs)
         else:
             # Plot the outgroup in light grey (these are counts not in *args)
-            gscat = self.scatter_simple(count_x_base,count_y_base, log_norm=log_norm, color='#B3B3B3', **kwargs)
+            gscat = self.scatter_simple(count_x_base,count_y_base, log_norm=log_norm, color='#A1A1A1', **kwargs)
 
         # Add each group to plot with a different color
         for group in argsit:

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -247,7 +247,7 @@ class plotterlib:
                                         log_norm=log_norm, color=next(colors), **kwargs)
         else:
             # Plot the outgroup in light grey (these are counts not in *args)
-            gscat = self.scatter_simple(count_x_base,count_y_base, log_norm=log_norm, color='#A1A1A1', **kwargs)
+            gscat = self.scatter_simple(count_x_base,count_y_base, log_norm=log_norm, color='#B3B3B3', **kwargs)
 
         # Add each group to plot with a different color
         for group in argsit:

--- a/tiny/templates/tinyrna-light.mplstyle
+++ b/tiny/templates/tinyrna-light.mplstyle
@@ -62,7 +62,7 @@ savefig.pad_inches: 0.1
 
 #### Font ####
 font.family: sans-serif
-font.sans-serif: Arial Unicode MS
+font.sans-serif: Arial
 font.size: 10
 
 #### TeX Font ####

--- a/tiny/templates/tinyrna-light.mplstyle
+++ b/tiny/templates/tinyrna-light.mplstyle
@@ -62,8 +62,11 @@ savefig.pad_inches: 0.1
 
 #### Font ####
 font.family: sans-serif
-font.sans-serif: Arial
+font.sans-serif: Arial Unicode MS
 font.size: 10
+
+#### TeX Font ####
+mathtext.default: regular
 
 #### Line style ####
 lines.linewidth: 1.0


### PR DESCRIPTION
The font for the Log2 subscript character now matches the surrounding font. Previously the subscript character used an uncommon font since it is inline mathtext. This prevents missing font errors when opening PDFs for editing.

Closes #161 