### PR TITLE
Counter and Plotter: new 5'NT/length distributions for assigned reads

### DIFF
--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -92,10 +92,15 @@ outputs:
     outputBinding:
       glob: $(inputs.out_prefix)_feature_counts.csv
 
-  other_counts:
+  mapped_nt_len_dist:
     type: File[]
     outputBinding:
-      glob: $(inputs.out_prefix)*_nt_len_dist.csv
+      glob: $(inputs.out_prefix)*_mapped_nt_len_dist.csv
+
+  assigned_nt_len_dist:
+    type: File[]
+    outputBinding:
+      glob: $(inputs.out_prefix)*_assigned_nt_len_dist.csv
 
   alignment_stats:
     type: File

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -206,8 +206,9 @@ steps:
       diagnostics: counter_diags
       fastp_logs: preprocessing/json_report_file
       collapsed_fa: preprocessing/uniq_seqs
-    out: [ feature_counts, other_counts, alignment_stats, summary_stats, console_output,
-           decollapsed_sams, intermed_out_files, alignment_diags, selection_diags ]
+    out: [ feature_counts, mapped_nt_len_dist, assigned_nt_len_dist,
+           alignment_stats, summary_stats, console_output, decollapsed_sams,
+           intermed_out_files, alignment_diags, selection_diags ]
 
   dge:
     run: ../tools/tiny-deseq.cwl
@@ -228,7 +229,9 @@ steps:
       dge_tables: dge/comparisons
       raw_counts: counter/feature_counts
       summ_stats: counter/summary_stats
-      len_dist: counter/other_counts
+      len_dist:
+        source: [ counter/mapped_nt_len_dist, counter/assigned_nt_len_dist ]
+        linkMerge: merge_flattened
       dge_pval: plot_pval
       style_sheet: plot_style_sheet
       out_prefix: run_name
@@ -276,9 +279,10 @@ steps:
     run: ../tools/make-subdir.cwl
     in:
       dir_files:
-        source: [ counter/feature_counts, counter/other_counts, counter/alignment_stats, counter/summary_stats,
-                  counter/intermed_out_files, counter/alignment_diags, counter/selection_diags, counter/console_output,
-                  counter/decollapsed_sams, features_csv ]
+        source: [ counter/feature_counts, counter/mapped_nt_len_dist, counter/assigned_nt_len_dist,
+                  counter/alignment_stats, counter/summary_stats, counter/console_output, counter/decollapsed_sams,
+                  counter/intermed_out_files, counter/alignment_diags, counter/selection_diags,
+                  features_csv ]
       dir_name: dir_name_counter
     out: [ subdir ]
 

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -85,11 +85,6 @@ def len_dist_plots(files_list: list, out_prefix:str, **kwargs):
     """
 
     for size_file in files_list:
-        # Read the size_dist file
-        size_dist = pd.read_csv(size_file, index_col=0)
-
-        # Create the plot
-        plot = aqplt.len_dist_bar(size_dist, **kwargs)
 
         # Parse the "sample_rep_N" string from the input filename to avoid duplicate out_prefix's in the basename
         basename = os.path.splitext(os.path.basename(size_file))[0]
@@ -103,6 +98,13 @@ def len_dist_plots(files_list: list, out_prefix:str, **kwargs):
         else:
             # File does not appear to have been produced by the pipeline
             condition_and_rep = basename
+
+        # Read the size_dist file
+        size_dist = pd.read_csv(size_file, index_col=0)
+
+        # Create the plot
+        subtype = "Assigned" if "assigned" in condition_and_rep else "Mapped"
+        plot = aqplt.len_dist_bar(size_dist, subtype, **kwargs)
 
         pdf_name = make_filename([out_prefix, condition_and_rep, "len_dist"], ext='.pdf')
         plot.figure.savefig(pdf_name)

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -48,11 +48,12 @@ class plotterlib:
         self.subplot_cache = {}
         self.dge_scatter_tick_cache = {}
 
-    def len_dist_bar(self, size_df: pd.DataFrame, **kwargs) -> plt.Axes:
+    def len_dist_bar(self, size_df: pd.DataFrame, subtype: str, **kwargs) -> plt.Axes:
         """Creates a stacked barplot of 5' end nucleotides by read length
 
         Args:
             size_df: A dataframe containing the size x 5'nt raw counts
+            subtype: The subtype of this len_dist plot so the title can be properly set
             kwargs: Additional keyword arguments to pass to pandas.DataFrame.plot()
 
         Returns:
@@ -72,7 +73,7 @@ class plotterlib:
         with plt.style.context(colors):
             plt.sca(ax)
             sizeb = size_prop.plot(kind='bar', stacked=True, reuse_plot=True, **kwargs)
-            sizeb.set_title('Distribution of aligned reads')
+            sizeb.set_title(f'Distribution of {subtype} Reads')
             sizeb.set_ylim(0,np.max(np.sum(size_prop, axis=1))+0.025)
             sizeb.set_ylabel('Proportion of Reads')
             sizeb.set_xlabel('Length of Sequence')


### PR DESCRIPTION
Counter now produces an additional 5'NT/length distribution matrix for assigned reads. This new output has "assigned_nt_len_dist" appended to its name. The previous length matrix output has been retained and now has "mapped_nt_len_dist" appended to its name.

Corresponding plots are produced by Plotter, and follow the same naming convention. len_dist plot titles now indicate which distribution subtype they display. An additional command line input was NOT created for these new plots; they are provided using the same "--len-dist" option. Plotter has no expectation that the "assigned_nt_len_dist" input will be provided. This PR is also backwards compatible with the old naming convention. If an nt_len_dist input is provided using the old naming convention, the outputs will also follow the old naming convention.

Closes #168 