### PR TITLE
Bugfix: helpstring in tiny-deseq.r is no longer truncated

### DIFF
--- a/tiny/rna/tiny-deseq.r
+++ b/tiny/rna/tiny-deseq.r
@@ -1,7 +1,6 @@
 #!/usr/bin/env Rscript
 
 #### ---- Validate the provided command line arguments ---- ####
-
 args <- commandArgs(trailingOnly = TRUE)
 usage <- "The following arguments are accepted:
 
@@ -26,6 +25,9 @@ usage <- "The following arguments are accepted:
        --drop-zero
               Optional. Prior to performing analysis, this will drop all
               rows/features which have a zero count in all samples."
+
+# Increase max error string length by the length of the usage string
+options(warning.length = getOption("warning.length") + nchar(usage))
 
 ## Returns the provided data as a dataframe with a corresponding classes column, regardless of order
 df_with_classes <- function(classless_df){


### PR DESCRIPTION
The size of the default max error string length is increased by the length of the usage string. If some condition caused a native error string to be collated with our own, then that error would likely respect a default maximum length and both strings could still be accommodated. While it isn't a guarantee, I believe this will be sufficient for our uses.