### PR TITLE
CWL: new bowtie options, small improvements to bowtie Run Config

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -160,51 +160,56 @@ compress: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- Max allowed num of mismatches --##
+##-- Report end-to-end hits w/ <=v mismatches; ignore qualities --##
 end_to_end: 0
 
-##-- If True: report all alignments --##
+##-- Report all alignments per read (much slower than low -k) --##
 all_aln: True
 
-##-- Set a random seed for alignment --##
+##-- Seed for random number generator --##
 seed: 0
 
-##-- If True: supress sam records for unaligned reads --##
+##-- Suppress SAM records for unaligned reads --##
 no_unal: True
 
-##-- If True: input files are fasta --##
-fasta: True
-
-##-- If True: output a sam file instead of stdout --##
-sam: True
-
-##-- If True: use shared mem for index; many bowtie's can share --##
+##-- Use shared mem for index; many bowtie's can share --##
 ##-- Note: this requires further configuration of your OS --##
 ##-- http://bowtie-bio.sourceforge.net/manual.shtml#bowtie-options-shmem --##
 shared_memory: False
 
 ###-- Unused option inputs: Remove '#' in front to use --###
-##-- If true: do not align to reverse-compliment reference --##
+##-- Hits are guaranteed best stratum, sorted; ties broken by quality --##
+#best: False
+
+##-- Hits in sub-optimal strata aren't reported (requires best, ^^^^) --##
+#strata: False
+
+##-- Max mismatches in seed (can be 0-3, default: -n 2) --##
+#seedmms: 2
+
+##-- Seed length for seedmms (default: 28) --##
+#seedlen: 28
+
+##-- Do not align to reverse-compliment reference --##
 # norc: False
 
-##-- If True: do not align to forward reference --##
+##-- Do not align to forward reference --##
 # nofw: False
 
-##-- If True: input quality scores are Phred64 --##
+##-- Input quals are Phred+64 (same as --solexa1.3-quals) --##
 # bt_phred64: False
 
-##-- If True: input files are fastq --##
-# fastq: False
-
-##-- Number of alignments to report --##
+##-- Report up to <int> good alignments per read (default: 1) --##
 # k_aln
 
 ##-- Number of bases to trim from 5' or 3' end of reads --##
 # trim5: 0
 # trim3: 0
 
-##-- If True: input files are solexa or solexa 1.3 quality --##
+##-- Input quals are from GA Pipeline ver. < 1.3 --##
 # solexa: false
+
+##-- Input quals are from GA Pipeline ver. >= 1.3 --##
 # solexa13: false
 
 

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -160,51 +160,56 @@ compress: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- Max allowed num of mismatches --##
+##-- Report end-to-end hits w/ <=v mismatches; ignore qualities --##
 end_to_end: 0
 
-##-- If True: report all alignments --##
+##-- Report all alignments per read (much slower than low -k) --##
 all_aln: True
 
-##-- Set a random seed for alignment --##
+##-- Seed for random number generator --##
 seed: 0
 
-##-- If True: supress sam records for unaligned reads --##
+##-- Suppress SAM records for unaligned reads --##
 no_unal: True
 
-##-- If True: input files are fasta --##
-fasta: True
-
-##-- If True: output a sam file instead of stdout --##
-sam: True
-
-##-- If True: use shared mem for index; many bowtie's can share --##
+##-- Use shared mem for index; many bowtie's can share --##
 ##-- Note: this requires further configuration of your OS --##
 ##-- http://bowtie-bio.sourceforge.net/manual.shtml#bowtie-options-shmem --##
 shared_memory: False
 
 ###-- Unused option inputs: Remove '#' in front to use --###
-##-- If true: do not align to reverse-compliment reference --##
+##-- Hits are guaranteed best stratum, sorted; ties broken by quality --##
+#best: False
+
+##-- Hits in sub-optimal strata aren't reported (requires best, ^^^^) --##
+#strata: False
+
+##-- Max mismatches in seed (can be 0-3, default: -n 2) --##
+#seedmms: 2
+
+##-- Seed length for seedmms (default: 28) --##
+#seedlen: 28
+
+##-- Do not align to reverse-compliment reference --##
 # norc: False
 
-##-- If True: do not align to forward reference --##
+##-- Do not align to forward reference --##
 # nofw: False
 
-##-- If True: input quality scores are Phred64 --##
+##-- Input quals are Phred+64 (same as --solexa1.3-quals) --##
 # bt_phred64: False
 
-##-- If True: input files are fastq --##
-# fastq: False
-
-##-- Number of alignments to report --##
+##-- Report up to <int> good alignments per read (default: 1) --##
 # k_aln
 
 ##-- Number of bases to trim from 5' or 3' end of reads --##
 # trim5: 0
 # trim3: 0
 
-##-- If True: input files are solexa or solexa 1.3 quality --##
+##-- Input quals are from GA Pipeline ver. < 1.3 --##
 # solexa: false
+
+##-- Input quals are from GA Pipeline ver. >= 1.3 --##
 # solexa13: false
 
 

--- a/tiny/cwl/tools/bowtie.cwl
+++ b/tiny/cwl/tools/bowtie.cwl
@@ -17,7 +17,7 @@ inputs:
   ebwt:
     type: string
     inputBinding:
-      position: 17
+      position: 23
     doc: "The basename of the index to be searched."
 
   # Only used by InitialWorkDirRequirement
@@ -29,13 +29,13 @@ inputs:
     type: File
     inputBinding:
       itemSeparator: ","
-      position: 18
+      position: 24
     doc: "Comma-separated list of files containing unpaired reads"
 
   outfile:
     type: string
     inputBinding:
-      position: 19
+      position: 25
     doc: "File to write hits to"
 
   logfile:
@@ -107,22 +107,57 @@ inputs:
     inputBinding:
       prefix: --nofw
       position: 8
-    doc: "do not align to forward/reverse-complement reference strand"
+    doc: "do not align to forward reference strand"
+
+  norc:
+    type: boolean?
+    inputBinding:
+      prefix: --norc
+      position: 9
+    doc: "do not align to reverse-complement reference strand"
+
+  seedmms:
+    type: int?
+    inputBinding:
+      prefix: --seedmms
+      position: 10
+    doc: "max mismatches in seed (can be 0-3, default: -n 2)"
+
+  seedlen:
+    type: int?
+    inputBinding:
+      prefix: --seedlen
+      position: 11
+    doc: "seed length for --seedmms (default: 28)"
 
   ### REPORTING ###
+
+  best:
+    type: boolean?
+    inputBinding:
+      prefix: --best
+      position: 12
+    doc: "hits guaranteed best stratum; ties broken by quality"
+
+  strata:
+    type: boolean?
+    inputBinding:
+      prefix: --strata
+      position: 13
+    doc: "hits in sub-optimal strata aren't reported (requires --best)"
 
   k_aln:
     type: int?
     inputBinding:
       prefix: -k
-      position: 9
+      position: 14
     doc: "report up to <int> good alignments per read (default: 1)"
 
   all_aln:
     type: boolean?
     inputBinding:
       prefix: --all
-      position: 10
+      position: 15
     default: true
     doc: "report all alignments per read (much slower than low -k)"
 
@@ -132,7 +167,7 @@ inputs:
     type: boolean?
     inputBinding:
       prefix: -t
-      position: 11
+      position: 16
     default: true
     doc: "print wall-clock time taken by search phases"
 
@@ -140,14 +175,14 @@ inputs:
     type: string?
     inputBinding:
       prefix: --un
-      position: 12
+      position: 17
     doc: "write unaligned reads/pairs to file(s) <fname>"
 
   no_unal:
     type: boolean?
     inputBinding:
       prefix: --no-unal
-      position: 12
+      position: 18
     default: true
     doc: "suppress SAM records for unaligned reads"
 
@@ -157,7 +192,7 @@ inputs:
     type: boolean?
     inputBinding:
       prefix: --sam
-      position: 13
+      position: 19
     default: true
     doc: "write hits in SAM format"
 
@@ -167,14 +202,14 @@ inputs:
     type: int?
     inputBinding:
       prefix: --threads
-      position: 14
+      position: 20
     doc: "number of alignment threads to launch (default: 1)"
 
   shared_memory:
     type: boolean?
     inputBinding:
       prefix: --shmem
-      position: 15
+      position: 21
     doc: "use shared mem for index; many bowtie's can share"
 
   ### OTHER ###
@@ -183,7 +218,7 @@ inputs:
     type: int?
     inputBinding:
       prefix: --seed
-      position: 16
+      position: 22
     doc: "seed for random number generator"
 
 outputs:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -65,6 +65,10 @@ inputs:
   end_to_end: int?
   nofw: boolean?
   norc: boolean?
+  seedmms: int?
+  seedlen: int?
+  best: boolean?
+  strata: boolean?
   k_aln: int?
   all_aln: boolean?
   no_unal: boolean?
@@ -179,6 +183,11 @@ steps:
       solexa13: solexa13
       end_to_end: end_to_end
       nofw: nofw
+      norc: norc
+      seedmms: seedmms
+      seedlen: seedlen
+      best: best
+      strata: strata
       k_aln: k_aln
       all_aln: all_aln
       no_unal: no_unal

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -55,8 +55,6 @@ inputs:
   # bowtie inputs
   bt_index_files: File[]
   ebwt: string
-  fastq: boolean?
-  fasta: boolean?
   trim5: int?
   trim3: int?
   bt_phred64: boolean?
@@ -72,7 +70,6 @@ inputs:
   k_aln: int?
   all_aln: boolean?
   no_unal: boolean?
-  sam: boolean?
   seed: int?
   shared_memory: boolean?
 
@@ -174,8 +171,6 @@ steps:
       ebwt: ebwt
       outfile: { valueFrom: $(inputs.sample_basename + "_aligned_seqs.sam") }
       logfile: { valueFrom: $(inputs.sample_basename + "_console_output.log") }
-      fastq: fastq
-      fasta: fasta
       trim5: trim5
       trim3: trim3
       phred64: bt_phred64
@@ -192,7 +187,6 @@ steps:
       all_aln: all_aln
       no_unal: no_unal
       un: { valueFrom: $(inputs.sample_basename + "_unaligned_seqs.fa") }
-      sam: sam
       threads: threads
       shared_memory: shared_memory
       seed: seed

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -160,51 +160,56 @@ compress: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- Max allowed num of mismatches --##
+##-- Report end-to-end hits w/ <=v mismatches; ignore qualities --##
 end_to_end: 0
 
-##-- If True: report all alignments --##
+##-- Report all alignments per read (much slower than low -k) --##
 all_aln: True
 
-##-- Set a random seed for alignment --##
+##-- Seed for random number generator --##
 seed: 0
 
-##-- If True: supress sam records for unaligned reads --##
+##-- Suppress SAM records for unaligned reads --##
 no_unal: True
 
-##-- If True: input files are fasta --##
-fasta: True
-
-##-- If True: output a sam file instead of stdout --##
-sam: True
-
-##-- If True: use shared mem for index; many bowtie's can share --##
+##-- Use shared mem for index; many bowtie's can share --##
 ##-- Note: this requires further configuration of your OS --##
 ##-- http://bowtie-bio.sourceforge.net/manual.shtml#bowtie-options-shmem --##
 shared_memory: False
 
 ###-- Unused option inputs: Remove '#' in front to use --###
-##-- If true: do not align to reverse-compliment reference --##
+##-- Hits are guaranteed best stratum, sorted; ties broken by quality --##
+#best: False
+
+##-- Hits in sub-optimal strata aren't reported (requires best, ^^^^) --##
+#strata: False
+
+##-- Max mismatches in seed (can be 0-3, default: -n 2) --##
+#seedmms: 2
+
+##-- Seed length for seedmms (default: 28) --##
+#seedlen: 28
+
+##-- Do not align to reverse-compliment reference --##
 # norc: False
 
-##-- If True: do not align to forward reference --##
+##-- Do not align to forward reference --##
 # nofw: False
 
-##-- If True: input quality scores are Phred64 --##
+##-- Input quals are Phred+64 (same as --solexa1.3-quals) --##
 # bt_phred64: False
 
-##-- If True: input files are fastq --##
-# fastq: False
-
-##-- Number of alignments to report --##
+##-- Report up to <int> good alignments per read (default: 1) --##
 # k_aln
 
 ##-- Number of bases to trim from 5' or 3' end of reads --##
 # trim5: 0
 # trim3: 0
 
-##-- If True: input files are solexa or solexa 1.3 quality --##
+##-- Input quals are from GA Pipeline ver. < 1.3 --##
 # solexa: false
+
+##-- Input quals are from GA Pipeline ver. >= 1.3 --##
 # solexa13: false
 
 


### PR DESCRIPTION
Closes #160 
Closes #177 

Options added to CWL and Run Config:
- --best
- --strata
- --seedmms
- --seedlen

Options removed from Run Config and Workflow:
- fasta
- fastq
- sam

The `norc` option had a partial CWL implementation. It has also been corrected.