### PR TITLE
Collapser: default trim value correction

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -144,10 +144,10 @@ compression: 4
 ######-------------------------------------------------------------------------------######
 
 ##-- Trim the specified number of bases from the 5' end of each sequence --#
-5p_trim: 1
+5p_trim: 0
 
 ##-- Trim the specified number of bases from the 3' end of each sequence --#
-3p_trim: 1
+3p_trim: 0
 
 ##-- Sequences with count <= threshold will be placed in a separate low_counts fasta --##
 threshold: 0

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - main
 dependencies:
-  - python
+  - python>=3.7
   - numpy==1.19.2
   - pandas==1.2.4
   - conda-forge::matplotlib==3.4.3

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - main
 dependencies:
-  - python>=3.7
+  - python
   - numpy==1.19.2
   - pandas==1.2.4
   - conda-forge::matplotlib==3.4.3


### PR DESCRIPTION
The default trim value was incorrectly set in the START_HERE Run Config. All other Run Config templates had the correct value.