### PR TITLE
Plotter: rule_charts for counts assigned per rule

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -266,6 +266,7 @@ dge_drop_zero: False
 ##-- Disable plots by commenting (adding a '#') for the undesired plot type --##
 plot_requests:
   - 'len_dist'
+  - 'rule_charts'
   - 'class_charts'
   - 'replicate_scatter'
   - 'sample_avg_scatter_by_dge'

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -266,6 +266,7 @@ dge_drop_zero: False
 ##-- Disable plots by commenting (adding a '#') for the undesired plot type --##
 plot_requests:
   - 'len_dist'
+  - 'rule_charts'
   - 'class_charts'
   - 'replicate_scatter'
   - 'sample_avg_scatter_by_dge'

--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -14,6 +14,12 @@ inputs:
       prefix: -rc
     doc: "Raw, non-normalized feature counts from Counter"
 
+  rule_counts:
+    type: File
+    inputBinding:
+      prefix: -uc
+    doc: "Raw, non-normalized counts by matched rule from Counter"
+
   norm_counts:
     type: File?
     inputBinding:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -228,6 +228,7 @@ steps:
       norm_counts: dge/norm_counts
       dge_tables: dge/comparisons
       raw_counts: counter/feature_counts
+      rule_counts: counter/rule_counts
       summ_stats: counter/summary_stats
       len_dist:
         source: [ counter/mapped_nt_len_dist, counter/assigned_nt_len_dist ]

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -16,8 +16,6 @@ import os
 
 # cwltool appears to unset all environment variables including those related to locale
 # This leads to warnings from plt's FontConfig manager, but only for pipeline/cwl runs
-from matplotlib.gridspec import GridSpec
-
 curr_locale = locale.getlocale()
 if curr_locale[0] is None:
     # Default locale otherwise unset
@@ -523,7 +521,7 @@ class plotterlib:
                 "scatter": ScatterCache
             }[plot_type]()
 
-        # if self.debug: plt.show(block=False)
+        if self.debug: plt.show(block=False)
         return cache.get()
 
 

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -125,12 +125,13 @@ class plotterlib:
 
         return cbar
 
-    def class_pie_barh(self, class_s: pd.Series, mapped_reads, scale=2, **kwargs) -> plt.Figure:
+    def class_pie_barh(self, class_s: pd.Series, mapped_reads_s: pd.Series, subtype: str, scale=2, **kwargs) -> plt.Figure:
         """Creates both a pie & bar chart of class proportions
 
         Args:
             class_s: A pandas Series containing counts per class for a sample
-            mapped_reads: The total number of reads mapped by bowtie for a sample
+            mapped_reads_s: The total number of reads mapped by bowtie for a sample
+            subtype: The subtype of this chart so the title can be properly set
             scale: The decimal scale for table percentages, and for determining "unassigned" display
             kwargs: Additional keyword arguments to pass to pandas.DataFrame.plot()
 
@@ -143,7 +144,7 @@ class plotterlib:
 
         # Convert reads to proportion
         scale += 2  # Convert percentage scale to decimal scale
-        class_prop = (class_s / mapped_reads).round(scale).rename('Proportion')
+        class_prop = (class_s / mapped_reads_s).round(scale).rename('Proportion')
 
         # Determine whether an unassigned category should be displayed
         unassigned = round(1 - class_prop.sum(), scale)
@@ -159,7 +160,7 @@ class plotterlib:
         table.auto_set_column_width(col=[0, 1])
 
         # finalize & save figure
-        fig.suptitle("Proportion of small RNAs by class", fontsize=22)
+        fig.suptitle(f"Proportion of small RNAs by {subtype}", fontsize=22)
         fig.subplots_adjust(top=0.85)
 
         return fig

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -148,6 +148,7 @@ class ResumePlotterConfig(ResumeConfig):
 
         inputs = {
             'raw_counts': {'var': "resume_raw", 'type': "File"},
+            'rule_counts': {'var': "resume_rule", 'type': "File"},
             'summ_stats': {'var': "resume_stat", 'type': "File"},
             'len_dist': {'var': "resume_len_dist", 'type': "File[]"}
         }
@@ -185,6 +186,7 @@ class ResumePlotterConfig(ResumeConfig):
         try:
             self['resume_raw'] = self.cwl_file(glob(counter + "/*_feature_counts.csv")[0])
             self['resume_stat'] = self.cwl_file(glob(counter + "/*_summary_stats.csv")[0])
+            self['resume_rule'] = self.cwl_file(glob(counter + "/*_counts_by_rule.csv")[0])
             self['resume_len_dist'] = list(map(self.cwl_file, glob(counter + "/*_nt_len_dist.csv")))
 
             if self.dge_ran:

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -266,6 +266,7 @@ dge_drop_zero: False
 ##-- Disable plots by commenting (adding a '#') for the undesired plot type --##
 plot_requests:
   - 'len_dist'
+  - 'rule_charts'
   - 'class_charts'
   - 'replicate_scatter'
   - 'sample_avg_scatter_by_dge'


### PR DESCRIPTION
Rule charts and class charts are now rendered as a horizontal bar chart rather than a pie chart + bar chart.

The following changes have been made to the *_charts:
- View limits are consistent across libraries for each run, just as they are in the scatter plots, and this view limit is determined by the largest proportion across libraries
- Bars are colored according to width using a continuous color map
- Percentage labels are lighter for smaller values and darker for larger values
- Percentage labels are vertically centered with the bar regardless of plot dimensions and group count. They also switch from right of terminus to left of terminus if the bar occupies more than 80% of the plot width

The following changes have been made to Counter's counts_by_rule.csv output:
- The index entry for each rule is now its row number in features.csv. The first rule is index 0. The table is sorted by ascending index.
- The next column after the index is the rule string
- Elipses in the rule string are removed before concatenation

This PR also addresses some minor inconsistencies in the internal naming conventions of Plotter's validate_inputs() and setup()

Closes #179 