### PR TITLE
Counter: relaxed GFF requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ To make it simple to specify your fastq files and their locations, along with as
 
 #### Features Sheet
 
-Small RNAs can often be classified by sequence characteristics, such as length, strandedness, and 5' nucleotide. We provide a Features Sheet (`features.csv`) in which you can define selection rules to more accurately capture counts for the small RNAs of interest.  Rules apply to features parsed from **all** Feature Sources, with the exception of "Alias by..." which only applies to the Feature Source on the same row. These rules are used to select among overlapping features at each alignment locus. Selection first takes place against feature attributes (GFF3 column 9), and is directed by defining the attribute you want to be considered (Select by...) and the acceptable values for that attribute (with value...). Rules that match features at this stage will be used in a second stage of selection which includes elimination by hierarchy and interval overlap characteristics. Remaining candidates pass to the third and final stage of selection which examines characteristics of the alignment itself: strand relative to the feature of interest, 5' end nucleotide, and length. See [Counter](doc/Counter.md) for more information.
+Small RNAs can often be classified by sequence characteristics, such as length, strandedness, and 5' nucleotide. We provide a Features Sheet (`features.csv`) in which you can define selection rules to more accurately capture counts for the small RNAs of interest.  Rules apply to features parsed from **all** Feature Sources, with the exception of "Alias by..." which only applies to the Feature Source on the same row. These rules are used to select among overlapping features at each alignment locus. Selection first takes place against feature attributes (GFF column 9), and is directed by defining the attribute you want to be considered (Select by...) and the acceptable values for that attribute (with value...). Rules that match features at this stage will be used in a second stage of selection which includes elimination by hierarchy and interval overlap characteristics. Remaining candidates pass to the third and final stage of selection which examines characteristics of the alignment itself: strand relative to the feature of interest, 5' end nucleotide, and length. See [Counter](doc/Counter.md) for more information.
 
->**Tip**: Don't worry about having duplicate Feature Source entries. Each GFF3 file is parsed only once.
+>**Tip**: Don't worry about having duplicate Feature Source entries. Each GFF file is parsed only once.
 
 ### User-Provided Input File Requirements
 
-  1. A GFF3 formatted file with with genomic coordinates for your features of interest, such as miRNAs (see c_elegans_WS279_chr1.gff3 in the reference_data folder for an example)
-     - Each feature must have an attributes column (column 9) which defines its `ID` and `Class` (case-sensitive).
-       - For example: `chrI	.	miRNA	100	121	.	+	.	ID=miR-1;Class=miRNA`
+  1. A GFF3 / GFF2 / GTF formatted file with genomic coordinates for your features of interest, such as miRNAs (see c_elegans_WS279_chr1.gff3 in the reference_data folder for an example)
+     - Each feature must have an attributes column (column 9) which defines its `ID`.
+       - For example: `chrI	.	miRNA	100	121	.	+	.	ID=miR-1;...`
      - All features must be stranded.
      - Attribute values which contain commas will be parsed as lists.
   2. FASTQ(.gz) <sup>*</sup> formatted files with your small RNA high-throughput sequencing data (files must be demultiplexed).
@@ -114,9 +114,9 @@ In most cases you will use this toolset as an end-to-end pipeline. This will run
 
 1. High-throughput sequencing data in fastq format. 
 2. The genome sequence of interest in fasta format.
-3. Genome coordinates of small RNA features of interest in gff3 format.
+3. Genome coordinates of small RNA features of interest in GFF format.
 4. A completed Samples Sheet (`samples.csv`) with paths to the fastq files.
-5. A completed Features Sheet (`features.csv`) with paths to the gff3 file(s).
+5. A completed Features Sheet (`features.csv`) with paths to the GFF file(s).
 6. An updated Paths File (`paths.yml`) with the path to the genome sequence.
 7. A Run Config file (`run_config.yml`) located in your working directory or the path to the file. The template provided does not need to be updated if you wish to use the default settings.
 
@@ -315,7 +315,7 @@ A "collapsed" FASTA contains unique reads found in fastp's quality filtered FAST
 The counter step produces a variety of outputs
 
 #### Feature Counts
-Custom Python scripts and HTSeq are used to generate a single table of feature counts that includes columns for each library analyzed. A feature's _Feature ID_ and _Feature Class_ are simply the values of its `ID` and `Class` attributes. We have also included a _Feature Name_ column which displays aliases of your choice, as specified in the _Alias by..._ column of the Features Sheet. If _Alias by..._ is set to`ID`, the _Feature Name_ column is left empty.
+Custom Python scripts and HTSeq are used to generate a single table of feature counts that includes columns for each library analyzed. A feature's _Feature ID_ and _Feature Class_ are simply the values of its `ID` and `Class` attributes. Features lacking a Class attribute will be assigned class `_UNKNOWN_`. We have also included a _Feature Name_ column which displays aliases of your choice, as specified in the _Alias by..._ column of the Features Sheet. If _Alias by..._ is set to`ID`, the _Feature Name_ column is left empty.
 
 For example, if your Features Sheet has a rule which specifies an ID Attribute of `sequence_name` and the GFF entry for this feature has the following attributes column:
 ```

--- a/START_HERE/features.csv
+++ b/START_HERE/features.csv
@@ -1,7 +1,7 @@
 Select for...,with value...,Alias by...,Hierarchy,Strand,5' End Nucleotide,Length,Match,Feature Source
 Class,miRNA,ID,1,sense,all,18-24,Partial,./reference_data/c_elegans_WS279_chr1.gff3
 Class,piRNA,ID,1,sense,U,19-21,Partial,./reference_data/c_elegans_WS279_chr1.gff3
-Class,CSR,ID,2,anstisense,G,21-23,Partial,./reference_data/c_elegans_WS279_chr1.gff3
-Class,WAGO,ID,2,anstisense,G,21-23,Partial,./reference_data/c_elegans_WS279_chr1.gff3
-Class,ALG,ID,2,anstisense,G,26,Partial,./reference_data/c_elegans_WS279_chr1.gff3
+Class,CSR,ID,2,antisense,G,21-23,Partial,./reference_data/c_elegans_WS279_chr1.gff3
+Class,WAGO,ID,2,antisense,G,21-23,Partial,./reference_data/c_elegans_WS279_chr1.gff3
+Class,ALG,ID,2,antisense,G,26,Partial,./reference_data/c_elegans_WS279_chr1.gff3
 biotype,transposon,ID,3,both,all,18-28,Full,./reference_data/c_elegans_WS279_chr1.gff3

--- a/doc/Counter.md
+++ b/doc/Counter.md
@@ -4,7 +4,7 @@ We provide a Features Sheet (`features.csv`) in which you can define selection r
 >**Important**: candidate features do not receive counts if they do not pass selection process described below
 
 Selection occurs in three stages, with the output of each stage as input to the next:
-1. Features are matched to rules based on their GFF3 column 9 attributes
+1. Features are matched to rules based on their GFF column 9 attributes
 2. Features which overlap an alignment are eliminated based on the hierarchy values and desired overlap characteristics defined in their mached rules
 3. Remaining feature candidates are then selected based on the small RNA attributes of the alignment to which they are being assigned. These attributes are, again, defined in each feature's matched rules
 
@@ -16,7 +16,7 @@ Each feature's column 9 attributes are searched for the key-value combinations d
 
 For example, if a rule contained `Class` and `WAGO` in these columns, then a feature with attributes<br>`... ;Class=CSR,WAGO; ...` would be considered a match for the rule.
 
->**Tip**: These parameters are case sensitive. The capitalization in your rule must match the capitalization in your GFF3 files
+>**Tip**: The rules defined in your Features Sheet are case-insensitive. You do not need to match the capitalization of your target attributes.
 
 ## Stage 2: Hierarchy and Overlap Parameters
 | features.csv columns: | Hierarchy | Match |
@@ -82,7 +82,7 @@ Examples:
 | features.csv columns: | Alias by... | Feature Source |
 | --- |-------------| --- |
 
-You may specify an **Alias by...** which is a GFF3 column 9 attribute key you wish to represent each feature. The intention of this column is to provide a human-friendly name for each feature. The value associated with each feature's **Alias by...** attribute will be shown in the `Feature Name` column of the Feature Counts output table.  For example, if one of your rules specifies an alias of `sequence_name` and gene1's `sequence_name` attribute is "abc123", then gene1's `Feature Name` column in the Feature Counts table will read "abc123".
+You may specify an **Alias by...** which is a GFF column 9 attribute key you wish to represent each feature. The intention of this column is to provide a human-friendly name for each feature. The value associated with each feature's **Alias by...** attribute will be shown in the `Feature Name` column of the Feature Counts output table.  For example, if one of your rules specifies an alias of `sequence_name` and gene1's `sequence_name` attribute is "abc123", then gene1's `Feature Name` column in the Feature Counts table will read "abc123".
 
 The **Feature Source** field of a rule is tied only to the **Alias by...**; rules are _not_ partitioned on a GFF file basis, and features parsed from these GFF files are similarly not partitioned as they all go into the same lookup table regardless of source. For each rule, aliases are built on a per-GFF file basis; that is, **Alias by...** values will only be gathered from their corresponding **Feature Source**. Additionally, each GFF file is parsed only once regardless of the number of times it occurs in the Features Sheet.
 
@@ -93,10 +93,10 @@ Small RNA reads passing selection will receive a normalized count increment. By 
 
 ### The Details
 You may encounter the following cases when you have more than one unique GFF file listed in your **Feature Source**s:
-- If a feature is defined in one GFF3 file, then again in another but with differing attributes, rule and alias matches will be merged for the feature
-- If a feature is defined in one GFF3 file, then again but under a different **Alias by...**, then both aliases are retained and treated as a list. All aliases will be present in the `Feature Name` column of the Feature Counts output table. They will be comma separated.
+- If a feature is defined in one GFF file, then again in another but with differing attributes, rule and alias matches will be merged for the feature
+- If a feature is defined in one GFF file, then again but under a different **Alias by...**, then both aliases are retained and treated as a list. All aliases will be present in the `Feature Name` column of the Feature Counts output table. They will be comma separated.
 
 Discontinuous features and feature filtering support:
 - Discontinuous features are supported (as defined by the `Parent` attribute key, or by a shared `ID` attribute value). Rule and alias matches of descendents are merged with the root parent's.
-- Features can be filtered during GFF3 parsing by on their `source` and/or `type` columns, and these preferences can be specified in the Run Config file. These are inclusive filters. Only features matching the values specified will be retained for selection. An empty list allows all values.
+- Features can be filtered during GFF parsing by on their `source` and/or `type` columns, and these preferences can be specified in the Run Config file. These are inclusive filters. Only features matching the values specified will be retained for selection. An empty list allows all values.
 - If a filtered feature breaks a feature lineage (that is, features chained via the `Parent` attribute), then the highest non-filtered ancestor is still considered to be the root parent. The lineage is maintained transparently but the filtered feature does not contribute to the domains of selection.


### PR DESCRIPTION
**Case sensitivity** is no longer required in the `Select for...` and `with value...` columns. More specifically, case does not need to match when examining a feature's attributes for an identity match. The original capitalization of both the attribute key and value is retained after a match is found, so capitalization in Counter's outputs will not be affected by this change.

**The Class attribute** is no longer required to be present in each feature's column 9 attributes. If the attribute is missing, a default Class value of `_UNKNOWN_` will be assigned to the feature. This default assignment takes place before stage 1 selection, so users may also define rules that `Select for: Class, with value: _unknown_`

**The GFF2 / GTF** is now listed as a supported format in the documentation, and references to GFF3 have been replaced with GFF to indicate wider support. This didn't require any code changes since the two formats are similar enough to GFF3 and HTSeq's GFF parser automatically handles the minor differences between formats. 

Closes #181 