### PR TITLE
Counter: basic support for SAM files produced outside of the pipeline

### DIFF
--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -509,7 +509,7 @@ class MyTestCase(unittest.TestCase):
         ]
 
         sam_out.assert_has_calls(expected_writelines)
-        self.assertTrue(len(reader._headers) == 1)
+        self.assertTrue(len(reader._header_lines) == 1)
 
     """Does SAM_reader._write_decollapsed_sam() write the correct number of duplicates to the decollapsed file?"""
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import mmap
 import json
@@ -11,6 +13,7 @@ from collections import Counter, defaultdict
 
 from ..util import make_filename
 
+_re_fastx = r'seq\d+_x(\d+)$'
 
 class LibraryStats:
 
@@ -43,8 +46,14 @@ class LibraryStats:
         loci_counts = len(aln_bundle)
         nt5, seqlen = bundle_read['nt5'], len(bundle_read['seq'])
 
+        try:
+            read_counts = int(bundle_read['name'].split('=')[1])
+        except IndexError:
+            # Check if fastx collapsed; default to count=1
+            fastx = re.match(_re_fastx, bundle_read['name'])
+            read_counts = 1 if fastx is None else int(fastx[1])
+
         # Calculate counts for multi-mapping
-        read_counts = int(bundle_read['name'].split('=')[1])
         corr_counts = read_counts / loci_counts
 
         # Fill in 5p nt/length matrix

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -11,9 +11,9 @@ from abc import abstractmethod, ABC
 from typing import Tuple, Optional
 from collections import Counter, defaultdict
 
+from tiny.rna.counter.hts_parsing import _re_fastx
 from ..util import make_filename
 
-_re_fastx = r'seq\d+_x(\d+)$'
 
 class LibraryStats:
 


### PR DESCRIPTION
Counter now offers basic support for counting SAM files which were not produced by the pipeline. This commit simply changes how sequence counts are determined from each alignment's QNAME field. If this field does not have Collapser's signature "#_count=#" format, it next attempts to parse fastx_collapser's signature "seq#_x#" format. If that fails the alignment's sequence defaults to a count of 1. More broadly speaking, if Counter fails to parse the QNAME field, a default count of 1 is assumed.

**THAT BEING SAID, if the SAM file hasn't been collapsed by fastx_collapser and is truly "uncollapsed", this will produce incorrect counts for the following stats:**
- Assigned Single/Multi-Mapping Reads
- All Sequence-related stats
- All summary stats derived from the above