### PR TITLE
Plotter: improvements and options for handling min and/or max lengths in len_dist plots

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -143,10 +143,10 @@ compression: 4
 #
 ######-------------------------------------------------------------------------------######
 
-##-- Trim the specified number of bases from the 5' end of each sequence --#
+##-- Trim the specified number of bases from the 5' end of each sequence --##
 5p_trim: 0
 
-##-- Trim the specified number of bases from the 3' end of each sequence --#
+##-- Trim the specified number of bases from the 3' end of each sequence --##
 3p_trim: 0
 
 ##-- Sequences with count <= threshold will be placed in a separate low_counts fasta --##
@@ -288,6 +288,10 @@ plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False
+
+##-- Optionally set the min and/or max lengths for len_dist plots; auto if unset --##
+plot_len_dist_min:
+plot_len_dist_max:
 
 
 ######----------------------------- OUTPUT DIRECTORIES ------------------------------######

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -143,10 +143,10 @@ compression: 4
 #
 ######-------------------------------------------------------------------------------######
 
-##-- Trim the specified number of bases from the 5' end of each sequence --#
+##-- Trim the specified number of bases from the 5' end of each sequence --##
 5p_trim: 0
 
-##-- Trim the specified number of bases from the 3' end of each sequence --#
+##-- Trim the specified number of bases from the 3' end of each sequence --##
 3p_trim: 0
 
 ##-- Sequences with count <= threshold will be placed in a separate low_counts fasta --##
@@ -288,6 +288,10 @@ plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False
+
+##-- Optionally set the min and/or max lengths for len_dist plots; auto if unset --##
+plot_len_dist_min:
+plot_len_dist_max:
 
 
 ######----------------------------- OUTPUT DIRECTORIES ------------------------------######

--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -62,6 +62,18 @@ inputs:
       prefix: -v
     doc: "If provided, scatter plots will have vectorized points (slower)"
 
+  len_dist_min:
+    type: int?
+    inputBinding:
+      prefix: -ldi
+    doc: "The first length to plot in the range for len_dist plots"
+
+  len_dist_max:
+    type: int?
+    inputBinding:
+      prefix: -lda
+    doc: "The last length to plot in the range for len_dist plots"
+
   out_prefix:
     type: string?
     inputBinding:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -97,6 +97,8 @@ inputs:
   # plotter options
   plot_requests: string[]
   plot_vector_points: boolean?
+  plot_len_dist_min: int?
+  plot_len_dist_max: int?
   plot_style_sheet: File?
   plot_pval: float?
 
@@ -240,6 +242,16 @@ steps:
       len_dist:
         source: [ counter/mapped_nt_len_dist, counter/assigned_nt_len_dist ]
         linkMerge: merge_flattened
+      len_dist_min:
+        source: [ plot_len_dist_min, length_required ]
+        pickValue: all_non_null
+        valueFrom: |
+          $(self.length ? self[0] : null)
+      len_dist_max:
+        source: [ plot_len_dist_max, length_limit ]
+        pickValue: all_non_null
+        valueFrom: |
+          $(self.length ? self[0] : null)
       dge_pval: plot_pval
       style_sheet: plot_style_sheet
       out_prefix: run_name

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -109,11 +109,14 @@ def len_dist_plots(matrices: dict, out_prefix:str, vmin: int = None, vmax: int =
             continue
 
         for condition_and_rep, len_dist_df in libraries.items():
+            # Convert reads to proportion
+            size_prop = len_dist_df / len_dist_df.sum().sum()
+
             # Ensure that there are no gaps & close range's half-open interval
-            len_dist_df = len_dist_df.reindex(range(vmin, vmax + 1)).fillna(0)
+            size_prop = size_prop.reindex(range(vmin, vmax + 1)).fillna(0)
 
             # Create the plot
-            plot = aqplt.len_dist_bar(len_dist_df, subtype, **kwargs)
+            plot = aqplt.len_dist_bar(size_prop, subtype, **kwargs)
 
             # Save plot
             pdf_name = make_filename([out_prefix, condition_and_rep, "len_dist"], ext='.pdf')

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -516,9 +516,9 @@ class plotterlib:
         # Assume text for values <100 will have aspect ratio of 1.1:1
         while len(index) >= int(np.floor(length / (font_size * 1.1))):
             font_size -= 1
-            if font_size < 5:
-                print("WARNING: minimum font size reached while attempting to "
-                      "reduce xaxis tick label crowding.", file=sys.stderr)
+            if font_size <= 5:
+                print(f"WARNING: minimum font size ({font_size}) reached while attempting "
+                      "to reduce xaxis tick label crowding.", file=sys.stderr)
                 break
 
         return font_size

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -209,7 +209,7 @@ class ResumePlotterConfig(ResumeConfig):
         if not self.dge_ran:
             prune = set()
             for input_var, value in plotter_inputs.items():
-                if value.startswith('dge/'):
+                if type(value) is str and value.startswith('dge/'):
                     prune.add(input_var)
             for input_var in prune:
                 del plotter_inputs[input_var]

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -143,10 +143,10 @@ compression: 4
 #
 ######-------------------------------------------------------------------------------######
 
-##-- Trim the specified number of bases from the 5' end of each sequence --#
+##-- Trim the specified number of bases from the 5' end of each sequence --##
 5p_trim: 0
 
-##-- Trim the specified number of bases from the 3' end of each sequence --#
+##-- Trim the specified number of bases from the 3' end of each sequence --##
 3p_trim: 0
 
 ##-- Sequences with count <= threshold will be placed in a separate low_counts fasta --##
@@ -288,6 +288,10 @@ plot_pval: ~
 
 ##-- If True: scatter plot points will be vectorized. If False, only points are raster --##
 plot_vector_points: False
+
+##-- Optionally set the min and/or max lengths for len_dist plots; auto if unset --##
+plot_len_dist_min:
+plot_len_dist_max:
 
 
 ######----------------------------- OUTPUT DIRECTORIES ------------------------------######


### PR DESCRIPTION
Improvements and options have been added for managing len_dist plot bounds. On the command line the min and/or max (first/last) lengths can be optionally specified with:
- **--len-dist-min**
- **--len-dist-max**

If either is unspecified, the unspecified bound is determined from the data's bounds on a per-subtype basis (i.e. the "Mapped" subtype bounds are determined separately from the "Assigned" subtype). Bounds, whether calculated or specified, are fixed across all plots for each subtype.

Run Config entries have been added for user specification:
- `plot_len_dist_min`
- `plot_len_dist_max` 

If either of these values are unassigned, the workflow will first fall back to the corresponding entries for fastp (`length_required` and `length_limit`). These fastp values are also optional, so if they too are unspecified, then the workflow will not pass corresponding values on the command line and Plotter will default to determining bounds as described above.

Additionally:
- Plotter now ensures that the range of lengths plotted is continuous (no gaps) over a closed interval from min to max
- If min > max for one of the subtypes (e.g. if one of the bounds is unspecified and therefore calculated as such, or if a user mixes up the options) then Plotter will skip that subtype and print an error.
- The xtick label size is dynamically calculated in order to avoid crowding on the xaxis while maximizing size. If the calculated size is greater than the default size (`xtick.labelsize` in the stylesheet), then the default is used. If the calculated size is less than the min_size (which I chose to be 5 points), then the min_size will be used and a warning will be printed (this should be rare as it requires an exceptionally wide min/max delta)

The following demonstrates the new xtick label crowding mitigation (**NOTE: see lower comments on this PR; the first plot is inaccurate**):
![mapped_len_dist_20-30](https://user-images.githubusercontent.com/63317/164915179-528a8a37-7edd-4750-8d7e-9bc09db7153b.jpg)
![mapped_len_dist_15-35](https://user-images.githubusercontent.com/63317/164915178-d961b43a-a8ce-4aaa-8797-2857856bf9e8.jpg)
![mapped_len_dist_15-60](https://user-images.githubusercontent.com/63317/164915177-c3a10121-0847-4f43-b817-b2d43cffe1be.jpg)

Closes #191 