### PR TITLE
Counter and Plotter: N bases are now reported and plotted (if present) in len_dist outputs

### DIFF
--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -72,7 +72,10 @@ class SAM_reader:
                 # Note: we assume sRNA sequencing data is NOT reversely stranded
                 if (int(cols[1]) & 16):
                     strand = '-'
-                    nt5 = complement[seq[-1]]
+                    try:
+                        nt5 = complement[seq[-1]]
+                    except KeyError:
+                        nt5 = chr(seq[-1])
                 else:
                     strand = '+'
                     nt5 = chr(seq[0])

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -29,8 +29,8 @@ class LibraryStats:
         self.feat_counts = Counter()
         self.rule_counts = Counter()
         self.chrom_misses = Counter()
-        self.mapped_nt_len = {nt: Counter() for nt in ['A', 'T', 'G', 'C']}
-        self.assigned_nt_len = {nt: Counter() for nt in ['A', 'T', 'G', 'C']}
+        self.mapped_nt_len = defaultdict(Counter, {nt: Counter() for nt in ['A', 'T', 'G', 'C']})
+        self.assigned_nt_len = defaultdict(Counter, {nt: Counter() for nt in ['A', 'T', 'G', 'C']})
         self.library_stats = {stat: 0 for stat in LibraryStats.summary_categories}
 
     def assign_library(self, library: dict):
@@ -276,14 +276,29 @@ class NtLenMatrices(MergedStat):
 
         for lib_name, matrices in self.nt_len_matrices.items():
             sanitized_lib_name = lib_name.replace('/', '_')
+            self.write_mapped_len_dist(matrices[0], sanitized_lib_name)
+            self.write_assigned_len_dist(matrices[1], sanitized_lib_name)
 
-            # Whole number counts because number of reads mapped is always integer
-            mapped_nt_len_df = pd.DataFrame(matrices[0]).sort_index().fillna(0)
-            mapped_nt_len_df.to_csv(f'{self.prefix}_{sanitized_lib_name}_mapped_nt_len_dist.csv')
+    def write_mapped_len_dist(self, matrix, sanitized_lib_name):
+        # Whole number counts because number of reads mapped is always integer
+        mapped_nt_len_df = pd.DataFrame(matrix).sort_index().fillna(0)
+        mapped_nt_len_df.to_csv(f'{self.prefix}_{sanitized_lib_name}_mapped_nt_len_dist.csv')
 
-            # Fractional counts due to (loci count) and/or (assigned feature count) normalization
-            assigned_nt_len_df = pd.DataFrame(matrices[1]).sort_index().round(decimals=2).fillna(0)
-            assigned_nt_len_df.to_csv(f'{self.prefix}_{sanitized_lib_name}_assigned_nt_len_dist.csv')
+    def write_assigned_len_dist(self, matrix, sanitized_lib_name):
+        # Fractional counts due to (loci count) and/or (assigned feature count) normalization
+        assigned_nt_len_df = pd.DataFrame(matrix).sort_index().round(decimals=2)
+
+        # Drop non-nucleotide columns if they don't contain counts
+        empty_non_base_columns = {
+            col for col in
+            set(assigned_nt_len_df.columns) - {'A', 'T', 'G', 'C'}
+            if assigned_nt_len_df[col].isna().all()
+        } # Todo: likely a better way
+        assigned_nt_len_df.drop(empty_non_base_columns, axis='columns', inplace=True)
+
+        # Assign default count of 0 for remaining cases
+        assigned_nt_len_df.fillna(0, inplace=True)
+        assigned_nt_len_df.to_csv(f'{self.prefix}_{sanitized_lib_name}_assigned_nt_len_dist.csv')
 
 
 class AlignmentStats(MergedStat):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -289,12 +289,10 @@ class NtLenMatrices(MergedStat):
         assigned_nt_len_df = pd.DataFrame(matrix).sort_index().round(decimals=2)
 
         # Drop non-nucleotide columns if they don't contain counts
-        empty_non_base_columns = {
-            col for col in
-            set(assigned_nt_len_df.columns) - {'A', 'T', 'G', 'C'}
-            if assigned_nt_len_df[col].isna().all()
-        } # Todo: likely a better way
-        assigned_nt_len_df.drop(empty_non_base_columns, axis='columns', inplace=True)
+        assigned_nt_len_df.drop([
+            col for col, values in assigned_nt_len_df.iteritems()
+            if col not in ['A', 'T', 'G', 'C'] and values.isna().all()
+        ], axis='columns', inplace=True)
 
         # Assign default count of 0 for remaining cases
         assigned_nt_len_df.fillna(0, inplace=True)

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -138,11 +138,11 @@ def get_len_dist_dict(files_list: list) -> DefaultDict[str, Dict[str, pd.DataFra
     for file in sorted(files_list):
         # Parse the "sample_rep_N" string from the input filename to avoid duplicate out_prefixes in the basename
         basename = os.path.splitext(os.path.basename(file))[0]
-        date_prefix_pos = re.search(timestamp_format, basename).span()
+        date_prefix_pos = re.search(timestamp_format, basename)
 
         if date_prefix_pos is not None:
             # File is a pipeline product
-            begin = date_prefix_pos[1] + 1
+            begin = date_prefix_pos.end() + 1
             end = basename.rfind("_nt_len_dist")
             condition_and_rep = basename[begin:end]
         else:

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -66,8 +66,8 @@ class plotterlib:
         # Ensure xaxis tick labels won't be too crowded
         font_size = self.get_xtick_labelsize_for_axis(ax.xaxis, size_prop.index)
 
-        # Override default colors. User may override with kwargs. (Orange, Yellow-green, Blue, Pink)
-        colors = {'axes.prop_cycle': mpl.cycler(color=['#F78E2D', '#CBDC3F', '#4D8AC8', '#E06EAA'])}
+        # Override default colors. User may override with kwargs. (Orange, Yellow-green, Blue, Pink, Gray)
+        colors = {'axes.prop_cycle': mpl.cycler(color=['#F78E2D', '#CBDC3F', '#4D8AC8', '#E06EAA', '#B3B3B3'])}
 
         # The style context allows us to use temporary styles
         with plt.style.context(colors):


### PR DESCRIPTION
This PR introduces proper handling of non-nucleotide bases in SAM files. If present, these bases are now reported in corresponding nt_len_dist tables, and are shown in len_dist plots with a gray color.

This PR also includes a minor bugfix for how Plotter parses condition_and_rep from nt_len_dist filenames