### PR TITLE
Counter: support for wildcard keywords in Identity selectors

### DIFF
--- a/doc/Counter.md
+++ b/doc/Counter.md
@@ -27,11 +27,15 @@ Selection occurs in three stages, with the output of each stage as input to the 
 | features.csv columns: | Select for... | with value... |
 |-----------------------|---------------|---------------|
 
-Each feature's column 9 attributes are searched for the key-value combinations defined in the `Select for...` and `with value...` columns. Features, and the rules they matched, are retained for overlap evaluation at alignment loci. Attribute keys are allowed to have multiple comma separated values, and these values are treated as a list; only one of the listed values needs to match the `with value...` to be considered a valid match to the rule.
+Each feature's column 9 attributes are searched for the key-value combinations defined in the `Select for...` and `with value...` columns. Features, and the rules they matched, are retained for overlap evaluation at alignment loci. 
 
-For example, if a rule contained `Class` and `WAGO` in these columns, then a feature with attributes<br>`... ;Class=CSR,WAGO; ...` would be considered a match for the rule.
+#### Value Lists
+Attribute keys are allowed to have multiple comma separated values, and these values are treated as a list; only one of the listed values needs to match the `with value...` to be considered a valid match to the rule. For example, if a rule contained `Class` and `WAGO` in these columns, then a feature with attributes `... ;Class=CSR,WAGO; ...` would be considered a match for the rule.
 
 >**Tip**: The rules defined in your Features Sheet are case-insensitive. You do not need to match the capitalization of your target attributes.
+
+#### Wildcard Support
+Wildcard values (`all`, `*`, or an empty cell) can be used in these fields. With this functionality you can evaluate features for the presence of an attribute key without regarding its values, or you can check all attribute keys for the presence of a specific value, or you can skip Stage 1 selection altogether to permit the evaluation of the complete feature set in Stage 2. In the later case, feature-rule matching pairs still serve as the basis for selection; each rule still applies only to its matching subset from previous Stages.
 
 ## Stage 2: Hierarchy and Overlap Parameters
 | features.csv columns: | Hierarchy | Overlap |

--- a/tests/unit_tests_features.py
+++ b/tests/unit_tests_features.py
@@ -360,6 +360,28 @@ class FeaturesTests(unittest.TestCase):
         self.assertEqual(fs.choose(feat_B, aln['aln_exact']), {"3' Anchored Overlap (-)": {0}})
         self.assertEqual(fs.choose(feat_B, aln['aln_short']), {"3' Anchored Overlap (-)": {0}})
 
+    """Are wildcard keywords in identity selectors properly converted to a Wildcard object copy?"""
+
+    def test_wildcard_identities(self):
+        wildcard, non_wild = "all", "Non-wildcard"
+        one = [dict(deepcopy(rules_template[0]), Identity=(wildcard, non_wild)),
+               dict(deepcopy(rules_template[0]), Identity=(non_wild, wildcard))]
+        two = [dict(deepcopy(rules_template[0]), Identity=(wildcard, wildcard))]
+        non = [dict(deepcopy(rules_template[0]), Identity=(non_wild, non_wild))]
+        dup = deepcopy(two)
+
+        rules = [*one, *two, *non, *dup]
+
+        actual = FeatureSelector(rules, LibraryStats(normalize_by_hits=True)).inv_ident
+        expected = {
+            (Wildcard(), non_wild):   [0],
+            (non_wild,   Wildcard()): [1],
+            (Wildcard(), Wildcard()): [2, 4],
+            (non_wild,   non_wild):   [3]
+        }
+
+        self.assertDictEqual(actual, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -675,6 +675,23 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(cia['otherkey'], ('AtTrVaL2',))
         self.assertEqual(cia['attrkey'], ("AtTrVaL1", "AtTrVaL2"))
 
+    """Does CaseInsensitiveAttrs.contains_ident() properly handle wildcard queries?"""
+
+    def test_CaseInsensitiveAttrs_contains_ident_wildcard(self):
+        cia = CaseInsensitiveAttrs()
+
+        cia["AtTrKeY"] = ("AtTrVaL1", "AtTrVaL2")
+        cia["AtTrKeY2"] = ("AtTrVaL3",)
+        cia["AtTrKeY3"] = ("AtTrVaL4", "AtTrVaL5", "AtTrVaL6")
+
+        self.assertTrue(cia.contains_ident(("attrkey3", "attrval5")))
+        self.assertTrue(cia.contains_ident(("attrkey2", Wildcard())))
+        self.assertTrue(cia.contains_ident((Wildcard(), "attrval6")))
+        self.assertTrue(cia.contains_ident((Wildcard(), Wildcard())))
+
+        self.assertFalse(cia.contains_ident(("attrkey4", "attrval7")))
+        self.assertFalse(cia.contains_ident(("attrkey4", Wildcard())))
+        self.assertFalse(cia.contains_ident((Wildcard(), "attrval7")))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -168,7 +168,7 @@ class FeatureSelector:
     def build_selectors(rules_table) -> List[dict]:
         """Builds single/list/range/wildcard membership-matching selectors.
 
-        Applies to: strand, 5' end nucleotide, and identities containing wildcards
+        Applies to: strand, 5' end nucleotide, length, and identities containing wildcards
 
         This function replaces text-based selector definitions in the rules_table with
         their corresponding selector classes. Selector evaluation is then performed via

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -288,8 +288,8 @@ class CaseInsensitiveAttrs(Dict[str, tuple]):
         if key_type is str and val_type is Wildcard:
             return key in self
         if key_type is Wildcard and val_type is str:
-            for v in self.values():
-                if val in v: return True
+            for v in super(CaseInsensitiveAttrs, self).values():
+                if val in v.ci_val: return True
             else: return False
 
     # Dict methods not implemented which are invalid if delegated to dict class

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -4,9 +4,10 @@ import sys
 import re
 
 from collections import Counter, defaultdict, namedtuple
-from typing import Tuple, List, Dict, Iterator, Optional, DefaultDict, Set
+from typing import Tuple, List, Dict, Iterator, Optional, DefaultDict, Set, Union
 from inspect import stack
 
+from tiny.rna.counter.matching import Wildcard
 from tiny.rna.util import report_execution_time, make_filename
 
 # For parse_GFF_attribute_string()
@@ -269,12 +270,27 @@ class CaseInsensitiveAttrs(Dict[str, tuple]):
         yield from zip(self.keys(), self.values())
 
     # Non-overridden method
-    def contains_ident(self, query: tuple):
-        # Allows case-insensitive membership queries by (key, value)
-        key = query[0].lower()
-        val = query[1].lower()
-        return key in self and \
-               val in super(CaseInsensitiveAttrs, self).__getitem__(key).ci_val
+    def contains_ident(self, query: Tuple[Union[str, Wildcard], Union[str, Wildcard]]):
+        """Checks if the identity tuple is present in the dictionary. Wildcards are supported."""
+
+        key_type = type(query[0])
+        val_type = type(query[1])
+
+        key = query[0].lower() if key_type is str else query[0]
+        val = query[1].lower() if val_type is str else query[1]
+
+        if key_type is val_type is Wildcard:
+            return True
+        if key_type is val_type is str:
+            # Allows case-insensitive membership queries by (key, value)
+            return key in self and \
+                   val in super(CaseInsensitiveAttrs, self).__getitem__(key).ci_val
+        if key_type is str and val_type is Wildcard:
+            return key in self
+        if key_type is Wildcard and val_type is str:
+            for v in self.values():
+                if val in v: return True
+            else: return False
 
     # Dict methods not implemented which are invalid if delegated to dict class
     def update(self, other, **kwargs): self.not_implemented()

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -10,7 +10,7 @@ class Wildcard(metaclass=Singleton):
     kwds = ('all', 'both', '*', '')
 
     @staticmethod
-    def __contains__(_): return True
+    def __contains__(*_): return True
     def __repr__(_): return "<all>"
 
 

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -116,12 +116,14 @@ class IntervalSelector:
                self.end == other.end
 
 
-class IntervalPartialMatch(Wildcard, IntervalSelector):
+class IntervalPartialMatch(IntervalSelector):
     """This is a no-op filter
 
     Since StepVector only returns features that overlap each alignment by
     at least one base, no further evaluation is required when this filter
     is used by FeatureSelector.choose()"""
+
+    __contains__ = Wildcard.__contains__
 
     def __init__(self, iv: HTSeq.GenomicInterval):
         super().__init__(iv)

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -3,9 +3,11 @@
 import re
 import HTSeq
 
+from tiny.rna.util import Singleton
 
-class Wildcard:
-    __slots__ = ()
+
+class Wildcard(metaclass=Singleton):
+    kwds = ('all', 'both', '*', '')
 
     @staticmethod
     def __contains__(_): return True

--- a/tiny/rna/util.py
+++ b/tiny/rna/util.py
@@ -6,6 +6,15 @@ import os
 import re
 
 
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
 def report_execution_time(step_name: str):
     def timer(func):
         @functools.wraps(func)


### PR DESCRIPTION
Wildcard keywords are now allowed in the `Select for...` and `with value...` fields. Wildcards are allowed in _either_ field or both. These keywords have been extended to include an asterisk character "*" and an empty cell, and this applies to all selectors which allow wildcard keywords.

The Wildcard class now follows a singleton design pattern which is much more inline with its meaning.