### PR TITLE
Temporary solution for Bioconductor recipes on Bioconda while they implement a fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,7 @@ tinyRNA is a set of tools to simplify the analysis of next-generation sequencing
 
 ## Installation
 
-A setup script has been provided for easy installation of tinyRNA. The project and its dependencies will be installed in a conda environment named `tinyrna` after running the following commands in your terminal:
-
-```shell
-# Clone the repository into a local directory
- git clone https://github.com/MontgomeryLab/tinyrna.git
- cd tinyrna
-
-# Install the tinyrna environment and dependencies
-# A custom environment name can also be passed as a command line argument
- ./setup.sh
-```
+A setup script has been provided for easy installation of tinyRNA. First, download the latest release of tinyRNA from the [Releases link](https://github.com/MontgomeryLab/tinyRNA/releases) on the right sidebar. Decompress the downloaded file and navigate to the resulting directory in your terminal, then execute `./setup.sh`. This will install the project and its dependencies in a conda environment named `tinyrna`.
 
 If the installation script runs the Miniconda installer:
 - Press "q" if you find yourself trapped on the license page


### PR DESCRIPTION
Bioconductor components which are fetched by post-link.sh currently fail on installation because they have been moved. The target urls return HTTP 302 when referenced, and since post-link.sh does not use curl with the -L option, the redirect isn't followed and the installation script errors out. 

Please note that post-link.sh is a component specifically of Bioconductor packages, and that the root cause of the issue is out of our control but Bioconda is actively migrating all Bioconductor packages to fix the issue.

In the meantime, I am changing README.md to direct users to install via release 1.0.1 rather than fetching the master branch. This release did not use the Bioconductor packages hosted on Bioconda, so the issue is avoided.