### PR TITLE
Installation issue fix, lockfile creation script, and tiny-count command line argument updates

### DIFF
--- a/conda/conda-linux-64.lock
+++ b/conda/conda-linux-64.lock
@@ -209,7 +209,7 @@ https://conda.anaconda.org/conda-forge/linux-64/r-base-4.1.1-hb93adac_1.tar.bz2#
 https://conda.anaconda.org/main/linux-64/requests-2.28.1-py39h06a4308_0.tar.bz2#022a67a9547db5fdfa024f8bf69ab2ad
 https://conda.anaconda.org/main/linux-64/atk-1.0-2.36.0-ha1a6a79_0.tar.bz2#387649f0dd6e7540ac4ec9ebb40f89c4
 https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.40.0-r41hdfd78af_0.tar.bz2#73c383d354e038bb8b4de75715747071
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844f
 https://conda.anaconda.org/bioconda/linux-64/bioconductor-zlibbioc-1.40.0-r41h5c21468_1.tar.bz2#9d6da3b64060f38a57fa3fdb9e801210
 https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.12.11-pyhd8ed1ab_0.tar.bz2#6eefee9888f33f150b5d44d616b1a613
 https://conda.anaconda.org/conda-forge/linux-64/pyqtchart-5.12-py39h0fcd23e_8.tar.bz2#d7d18728be87fdc0ddda3e65d41caa53

--- a/conda/conda-linux-64.lock
+++ b/conda/conda-linux-64.lock
@@ -209,7 +209,7 @@ https://conda.anaconda.org/conda-forge/linux-64/r-base-4.1.1-hb93adac_1.tar.bz2#
 https://conda.anaconda.org/main/linux-64/requests-2.28.1-py39h06a4308_0.tar.bz2#022a67a9547db5fdfa024f8bf69ab2ad
 https://conda.anaconda.org/main/linux-64/atk-1.0-2.36.0-ha1a6a79_0.tar.bz2#387649f0dd6e7540ac4ec9ebb40f89c4
 https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.40.0-r41hdfd78af_0.tar.bz2#73c383d354e038bb8b4de75715747071
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_1.tar.bz2#6e1f609561c9649630efe729ed205131
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
 https://conda.anaconda.org/bioconda/linux-64/bioconductor-zlibbioc-1.40.0-r41h5c21468_1.tar.bz2#9d6da3b64060f38a57fa3fdb9e801210
 https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.12.11-pyhd8ed1ab_0.tar.bz2#6eefee9888f33f150b5d44d616b1a613
 https://conda.anaconda.org/conda-forge/linux-64/pyqtchart-5.12-py39h0fcd23e_8.tar.bz2#d7d18728be87fdc0ddda3e65d41caa53

--- a/conda/conda-osx-64.lock
+++ b/conda/conda-osx-64.lock
@@ -187,7 +187,7 @@ https://conda.anaconda.org/conda-forge/osx-64/r-base-4.1.1-h65845f3_1.tar.bz2#22
 https://conda.anaconda.org/conda-forge/osx-64/rdflib-6.0.2-py39h6e9494a_0.tar.bz2#63879b5da7907f45f78626b6457ea3ae
 https://conda.anaconda.org/main/osx-64/atk-1.0-2.36.0-hb642b71_0.tar.bz2#b8eac97ee6c0f859891a17db8677688e
 https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.40.0-r41hdfd78af_0.tar.bz2#73c383d354e038bb8b4de75715747071
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844f
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-zlibbioc-1.40.0-r41haba8685_1.tar.bz2#c3eb61b118b5d0962ea3df755c5cd055
 https://conda.anaconda.org/conda-forge/osx-64/r-backports-1.4.1-r41h28b5c78_0.tar.bz2#9c442653219c8fa9e4a9ed2a95644a4d
 https://conda.anaconda.org/conda-forge/noarch/r-bh-1.78.0_0-r41hc72bb7e_0.tar.bz2#4963f5da888bdbfb202b3612e11ba972

--- a/conda/conda-osx-64.lock
+++ b/conda/conda-osx-64.lock
@@ -265,7 +265,7 @@ https://conda.anaconda.org/conda-forge/osx-64/r-survival-3.3_1-r41h0f1d5c4_0.tar
 https://conda.anaconda.org/conda-forge/osx-64/r-vctrs-0.4.1-r41hc4bb905_0.tar.bz2#1693b30f880c5cd8a3cd36eedd2a3cfe
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-biocparallel-1.28.3-r41h7cba510_0.tar.bz2#8a1d491b537cd4e886e677ca3463471a
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-delayedarray-0.20.0-r41haba8685_1.tar.bz2#18b6dc7e658d6df39f3ea7b350812a8f
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodb-1.30.0-r41hdfd78af_0.tar.bz2#c55150adbc50b1d923d48d9bb126cf0f
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-xvector-0.34.0-r41haba8685_1.tar.bz2#aa8411a873df7f52f75872c75284427f
 https://conda.anaconda.org/conda-forge/osx-64/pydot-1.4.2-py39h6e9494a_2.tar.bz2#a28ed8d626bfe443d6f15322c486a04c
 https://conda.anaconda.org/main/noarch/pydotplus-2.0.2-py_3.tar.bz2#cfb123d1e6b3375ae2acab4c290390ae

--- a/conda/conda-osx-64.lock
+++ b/conda/conda-osx-64.lock
@@ -187,7 +187,7 @@ https://conda.anaconda.org/conda-forge/osx-64/r-base-4.1.1-h65845f3_1.tar.bz2#22
 https://conda.anaconda.org/conda-forge/osx-64/rdflib-6.0.2-py39h6e9494a_0.tar.bz2#63879b5da7907f45f78626b6457ea3ae
 https://conda.anaconda.org/main/osx-64/atk-1.0-2.36.0-hb642b71_0.tar.bz2#b8eac97ee6c0f859891a17db8677688e
 https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.40.0-r41hdfd78af_0.tar.bz2#73c383d354e038bb8b4de75715747071
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_1.tar.bz2#6e1f609561c9649630efe729ed205131
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-zlibbioc-1.40.0-r41haba8685_1.tar.bz2#c3eb61b118b5d0962ea3df755c5cd055
 https://conda.anaconda.org/conda-forge/osx-64/r-backports-1.4.1-r41h28b5c78_0.tar.bz2#9c442653219c8fa9e4a9ed2a95644a4d
 https://conda.anaconda.org/conda-forge/noarch/r-bh-1.78.0_0-r41hc72bb7e_0.tar.bz2#4963f5da888bdbfb202b3612e11ba972
@@ -265,7 +265,7 @@ https://conda.anaconda.org/conda-forge/osx-64/r-survival-3.3_1-r41h0f1d5c4_0.tar
 https://conda.anaconda.org/conda-forge/osx-64/r-vctrs-0.4.1-r41hc4bb905_0.tar.bz2#1693b30f880c5cd8a3cd36eedd2a3cfe
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-biocparallel-1.28.3-r41h7cba510_0.tar.bz2#8a1d491b537cd4e886e677ca3463471a
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-delayedarray-0.20.0-r41haba8685_1.tar.bz2#18b6dc7e658d6df39f3ea7b350812a8f
-https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodbdata-1.2.7-r41hdfd78af_2.tar.bz2#b23c1905f6ee6dddcfa3af515aa4844fs
+https://conda.anaconda.org/bioconda/noarch/bioconductor-genomeinfodb-1.30.0-r41hdfd78af_0.tar.bz2#c55150adbc50b1d923d48d9bb126cf0f
 https://conda.anaconda.org/bioconda/osx-64/bioconductor-xvector-0.34.0-r41haba8685_1.tar.bz2#aa8411a873df7f52f75872c75284427f
 https://conda.anaconda.org/conda-forge/osx-64/pydot-1.4.2-py39h6e9494a_2.tar.bz2#a28ed8d626bfe443d6f15322c486a04c
 https://conda.anaconda.org/main/noarch/pydotplus-2.0.2-py_3.tar.bz2#cfb123d1e6b3375ae2acab4c290390ae

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - conda-forge::mscorefonts==0.0.1
   - conda-forge::psutil==5.9.1
   - conda-forge::r-base==4.1.1
-  - pip:
-    - ../ # Install tinyRNA via setup.py
+  # tinyRNA codebase must be installed via pip in root project dir
 variables:
   - PYTHONNOUSERSITE: 1

--- a/conda/update-lockfiles.sh
+++ b/conda/update-lockfiles.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+dev_env_name="tinyrna_dev_v1.0"
+dev_deps="conda-forge::conda-lock python=3.9"
+
+#==== FUNCTION DEFINITIONS ================================================================
+
+function check_lockfile_update_status() {
+  if [[ $1 -eq 4 ]]; then
+    # Supposedly reported with --check-input-hash
+    # However this appears to not apply to subdependencies
+    success "No updates for lockfile"
+  elif [[ $1 -eq 0 ]]; then
+    success "Lockfile has been updated"
+  else
+    fail "Error occurred while updating lockfile. Please see the associated log file."
+    exit 1
+  fi
+}
+
+function success() {
+  check="✓"
+  green_on="\033[1;32m"
+  green_off="\033[0m"
+  printf "${green_on}${check} %s${green_off}\n" "$*"
+}
+
+function status() {
+  blue_on="\033[1;34m"
+  blue_off="\033[0m"
+  printf "${blue_on}%s${blue_off}\n" "$*"
+}
+
+function fail() {
+  nope="⃠"
+  red_on="\033[1;31m"
+  red_off="\033[0m"
+  printf "${red_on}${nope} %s${red_off}\n" "$*"
+}
+
+#==== MAIN ROUTINE ========================================================================
+
+# Check if os is mac or linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  success "macOS detected"
+  shell=$(basename "$(dscl . -read ~/ UserShell | cut -f 2 -d " ")")
+elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+  success "Linux detected"
+  shell="$(basename "$SHELL")"
+else
+  fail "Unsupported OS"
+  exit 1
+fi
+
+# Enable the use of Conda commands in this script
+eval "$(conda shell."$shell" hook)"
+
+# Create the dev environment if needed
+if ! conda env list | grep -q ${dev_env_name}; then
+  status "Creating ${dev_env_name} environment..."
+  conda create --name "${dev_env_name}" --yes "${dev_deps}" 2>&1 | tee "dev_env_create.log"
+fi
+
+# Activate dev environment
+conda activate "${dev_env_name}"
+
+# Update Linux lockfile
+status "Updating linux-64 lockfile..."
+conda-lock lock --kind explicit --platform linux-64 --file environment.yml > "linux_lockfile.log" 2>&1
+
+# Check result for Linux lockfile
+check_lockfile_update_status $?
+
+# Update macOS lockfile
+status "Updating osx-64 lockfile..."
+conda-lock lock --kind explicit --platform osx-64 --file environment.yml > "osx_lockfile.log" 2>&1
+
+# Check result for OSX lockfile
+check_lockfile_update_status $?

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -21,10 +21,10 @@ inputs:
     inputBinding:
       prefix: -i
 
-  config_csv:
+  features_csv:
     type: File
     inputBinding:
-      prefix: -c
+      prefix: -f
 
   out_prefix:
     type: string

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -202,7 +202,7 @@ steps:
     run: ../tools/tiny-count.cwl
     in:
       samples_csv: samples_csv
-      config_csv: features_csv
+      features_csv: features_csv
       aligned_seqs: bowtie/sam_out
       gff_files: gff_files
       out_prefix: run_name

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -183,10 +183,10 @@ def main():
 
     try:
         # Determine SAM inputs and their associated library names
-        libraries = load_samples(args.input_csv, args.is_pipeline)
+        libraries = load_samples(args.samples_csv, args.is_pipeline)
 
-        # Load selection rules and feature sources from config
-        selection_rules, gff_file_set = load_config(args.config, args.is_pipeline)
+        # Load selection rules and feature sources from the Features Sheet
+        selection_rules, gff_file_set = load_config(args.features_csv, args.is_pipeline)
 
         # global for multiprocessing
         global counter

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -150,7 +150,7 @@ class MergedStatsManager:
         MergedStat.prefix = prefs.get('out_prefix', '')
 
         self.merged_stats = [
-            FeatureCounts(Features_obj), RuleCounts(prefs['config']),
+            FeatureCounts(Features_obj), RuleCounts(prefs['features_csv']),
             AlignmentStats(), SummaryStats(),
             NtLenMatrices()
         ]


### PR DESCRIPTION
Updated the URL in lockfiles for bioconductor-genomeinfodbdata to use the latest build, which fixes an issue in the recipe that prevented tinyRNA installation (many thanks to Tai for tracking this down).

I've also added a script to automate the process of updating the lockfiles per the contents of environment.yml, which will also include updated build numbers for the entire dependency tree. The script can be used to remedy future issues like this. Note that it was NOT used for the lockfile changes included in this PR since the build updates were quite extensive and I have time limitations for testing this week

tiny-count's --features-csv short argument was changed from -c to -f when 3rd party SAM file support was added. This change was made hastily and a bit last minute, and since it was unrelated to the issue I overlooked some necessary updates for the new argument names. The CommandLineTool and Workflow CWL, as well as codebase references, have been updated to reflect this change.

Closes #224 