### PR TITLE
Pipeline: new location and scope for GFF Source Filters and Column Filters

### DIFF
--- a/START_HERE/features.csv
+++ b/START_HERE/features.csv
@@ -1,7 +1,7 @@
-Select for...,with value...,Tag,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
-Class,mask,,1,both,all,all,Partial
-Class,miRNA,,2,sense,all,16-22,Full
-Class,piRNA,5pA,2,both,A,24-32,Full
-Class,piRNA,5pT,2,both,T,24-32,Full
-Class,siRNA,,2,both,all,15-22,Full
-Class,unk,,3,both,all,all,Full
+Select for...,with value...,Tag,Source Filter,Type Filter,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
+Class,mask,,,,1,both,all,all,Partial
+Class,miRNA,,,,2,sense,all,16-22,Full
+Class,piRNA,5pA,,,2,both,A,24-32,Full
+Class,piRNA,5pT,,,2,both,T,24-32,Full
+Class,siRNA,,,,2,both,all,15-22,Full
+Class,unk,,,,3,both,all,all,Full

--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -233,13 +233,6 @@ counter_normalize_by_hits: True
 ##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
 counter_decollapse: False
 
-##-- Only parse GFF lines that match these values on column 2. [] is wildcard --##
-counter_source_filter: []
-
-##-- Only parse GFF lines that match these values on column 3. [] is wildcard --##
-##-- If source AND type filters are given, a line must match both to be included --##
-counter_type_filter: []
-
 ##-- Select the StepVector implementation that is used. Options: HTSeq or Cython --##
 counter_stepvector: 'Cython'
 

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -67,7 +67,7 @@ reference_genome_files:
 - /absolute/path/genome2.fasta
 
 # Brackets can be used for more compact lists
-source_filter: [source1, source2, source3]
+alias: [attribute1, attribute2, attribute3]
 ```
 
 #### Strings
@@ -123,9 +123,9 @@ Supported values are:
 DESeq2 requires that your experiment design has at least one degree of freedom. If your experiment doesn't include at least one sample group with more than one replicate, tiny-deseq.r will be skipped and DGE related plots will not be produced.
 
 ## Features Sheet Details
-| _Column:_  | Select for... | with value... | Alias by... | Tag | Hierarchy | Strand | 5' End Nucleotide | Length | Overlap     | Feature Source |
-|------------|---------------|---------------|-------------|-----|-----------|--------|-------------------|--------|-------------|----------------|
-| _Example:_ | Class         | miRNA         | Name        |     | 1         | sense  | all               | all    | 5' anchored | ram1.gff3      |
+| _Column:_  | Select for... | with value... | Alias by... | Source Filter | Type filter | Tag | Hierarchy | Strand | 5' End Nucleotide | Length | Overlap     | Feature Source |
+|------------|---------------|---------------|-------------|---------------|-------------|-----|-----------|--------|-------------------|--------|-------------|----------------|
+| _Example:_ | Class         | miRNA         | Name        |               |             |     | 1         | sense  | all               | all    | 5' anchored | ram1.gff3      |
 
 The Features Sheet allows you to define selection rules that determine how features are chosen when multiple features are found overlap an alignment locus. Selected features are "assigned" a portion of the reads associated with the alignment.
 

--- a/doc/Parameters.md
+++ b/doc/Parameters.md
@@ -84,14 +84,6 @@ By default, tiny-count will divide the number of counts associated with each seq
 
 The SAM files produced by the tinyRNA pipeline are collapsed by default; alignments sharing a SEQ field are strictly multi-alignments and do not reflect original sequence counts. If this option is switched "on", tiny-count will produce a decollapsed copy of each input SAM file. Each alignment in the decollapsed SAM will be duplicated by the sequence's original count. This is useful for browsing in IGV. If non-collapsed inputs are provided to tiny-count in standalone mode, this option will be ignored.
 
-### Filters
- | Run Config Key                 | Commandline Argument                       |
-|--------------------------------|--------------------------------------------|
-| counter_source_filter: [ ]     | `--source-filter SOURCE SOURCE SOURCE ...` | 
-| counter_type_filter: [ ]       | `--type-filter TYPE TYPE TYPE ...`         |
-
-You can optionally filter features in your GFF files by specifying sources and/or types that are desired. Source and type refer to GFF columns 2 and 3 respectively. If source _and_ type filters are specified, each feature must match one of the sources _and_ one of the types in order to be included in the counting process. For both filters, an empty list is the same as "allow all."
-
 ### StepVector
 | Run Config Key     | Commandline Argument |
 |--------------------|----------------------|
@@ -122,9 +114,8 @@ Diagnostic information will include intermediate alignment files for each librar
 
 ### Full tiny-count Help String
 ```
-tiny-count -i SAMPLES -f FEATURES -o OUTPUTPREFIX [-h]
-           [-sf [SOURCE ...]] [-tf [TYPE ...]] [-nh T/F] [-dc] [-a]
-           [-p] [-d]
+tiny-count -pf PATHS -o OUTPUTPREFIX [-h] [-nh T/F] [-dc]
+           [-sv {Cython,HTSeq}] [-a] [-p] [-d]
 
 This submodule assigns feature counts for SAM alignments using a Feature Sheet
 ruleset. If you find that you are sourcing all of your input files from a
@@ -132,21 +123,13 @@ prior run, we recommend that you instead run `tiny recount` within that run's
 directory.
 
 Required arguments:
-  -i SAMPLES, --samples-csv SAMPLES
-                        your Samples Sheet
-  -f FEATURES, --features-csv FEATURES
-                        your Features Sheet
+  -pf PATHS, --paths-file PATHS
+                        your Paths File
   -o OUTPUTPREFIX, --out-prefix OUTPUTPREFIX
                         output prefix to use for file names
 
 Optional arguments:
   -h, --help            show this help message and exit
-  -sf [SOURCE ...], --source-filter [SOURCE ...]
-                        Only produce counts for features whose GFF column 2
-                        matches the source(s) listed
-  -tf [TYPE ...], --type-filter [TYPE ...]
-                        Only produce counts for features whose GFF column 3
-                        matches the type(s) listed
   -nh T/F, --normalize-by-hits T/F
                         If T/true, normalize counts by (selected) overlapping
                         feature counts. Default: true.
@@ -156,9 +139,6 @@ Optional arguments:
   -sv {Cython,HTSeq}, --stepvector {Cython,HTSeq}
                         Select which StepVector implementation is used to find
                         features overlapping an interval.
-  -md, --multi-id       Don't treat features with multiple ID values as an
-                        error. Only the first value will be used as the
-                        feature's ID.
   -a, --all-features    Represent all features in output counts table, even if
                         they did not match a Select for / with value.
   -p, --is-pipeline     Indicates that tiny-count was invoked as part of a

--- a/doc/tiny-count.md
+++ b/doc/tiny-count.md
@@ -21,23 +21,26 @@ We provide a Features Sheet (`features.csv`) in which you can define selection r
 >**Important**: candidate features do not receive counts if they do not pass the selection process described below
 
 Selection occurs in three stages, with the output of each stage as input to the next:
-1. Features are matched to rules based on their GFF column 9 attributes
+1. Features are matched to rules based on their attributes defined in GFF files
 2. At each alignment locus, overlapping features are selected based on the overlap requirements of their matched rules. Selected features are sorted by hierarchy value so that smaller values take precedence in the next stage.
 3. Finally, features are selected for read assignment based on the small RNA attributes of the alignment locus. Once reads are assigned to a feature, they are excluded from matches with larger hierarchy values.
  
 ## Stage 1: Feature Attribute Parameters
-| _features.csv columns:_ | Select for... | with value... | Tag |
-|-------------------------|---------------|---------------|-----|
+| _features.csv columns:_ | Select for... | with value... | Tag | Source Filter | Type Filter |
+|-------------------------|---------------|---------------|-----|---------------|-------------|
 
-Each feature's column 9 attributes are searched for the key-value combinations defined in the `Select for...` and `with value...` columns. Features, and the rules they matched, are retained for later evaluation at alignment loci in Stages 2 and 3.
+Each feature's column 9 attributes are searched for the key-value combinations defined in the `Select for...` and `with value...` columns. These matches are then filtered based on their source (GFF column 2) and type (GFF column 3) according to the corresponding rule's `Source Filter`, and `Type Filter`. Features, and the rules they matched, are retained for later evaluation at alignment loci in Stages 2 and 3.
+
+#### Source and Type Filters
+These are inclusive filters, meaning a feature's source/type must match one of the values in these columns to pass Stage 1 selection. If these fields are left empty, or any wildcard value is used, then the feature's source/type is not evaluated.
 
 #### Value Lists
-Attribute keys are allowed to have multiple comma separated values, and these values are treated as a list; only one of the listed values needs to match the `with value...` to be considered a valid match to the rule. For example, if a rule contained `Class` and `WAGO` in these columns, then a feature with attributes `... ;Class=CSR,WAGO; ...` would be considered a match for the rule.
+Attribute keys are allowed to have multiple comma separated values, and these values are treated as a list; only one of the listed values needs to match the `with value...` to be considered a valid match to the rule. For example, if a rule contained `Class` and `WAGO` in these columns, then a feature with attributes `... ;Class=CSR,WAGO; ...` would be considered a match for the rule. Value lists can also be used in the `Source/Type Filter` fields.
 
 >**Tip**: The rules defined in your Features Sheet are case-insensitive. You do not need to match the capitalization of your target attributes.
 
 #### Wildcard Support
-Wildcard values (`all`, `*`, or an empty cell) can be used in the `Select for...` / `with value...` fields. With this functionality you can evaluate features for the presence of an attribute key without regarding its values, or you can check all attribute keys for the presence of a specific value, or you can skip Stage 1 selection altogether to permit the evaluation of the complete feature set in Stage 2. In the later case, feature-rule matching pairs still serve as the basis for selection; each rule still applies only to its matching subset from previous Stages.
+Wildcard values (`all`, `*`, or an empty cell) can be used in the `Select for...`, `with value...`, `Source Filter`, and `Type Filter` fields. With this functionality you can evaluate features for the presence of an attribute key without regarding its values, or you can check all attribute keys for the presence of a specific value, or you can skip Stage 1 selection altogether to permit the evaluation of the complete feature set in Stage 2. In the later case, feature-rule matching pairs still serve as the basis for selection; each rule still applies only to its matching subset from previous Stages.
 
 #### Tagged Counting (advanced)
 You can optionally specify a tag for each rule. Feature assignments resulting from tagged rules will have reads counted separately from those assigned by non-tagged rules. This essentially creates a new "sub-feature" for each feature that a tagged rule matches, and these "sub-features" are treated as distinct during downstream DGE analysis. Additionally, these counts subsets can be pooled across any number of rules by specifying the same tag. We recommend using tag names which _do not_ pertain to the `Select for...` / `with value...` in order to avoid potentially confusing results in class-related plots. 
@@ -132,5 +135,4 @@ You may encounter the following cases when you have more than one unique GFF fil
 Discontinuous features and feature filtering support:
 - Discontinuous features are supported (as defined by the `Parent` attribute key, or by a shared `ID`/`gene_id` attribute value). Rule and alias matches of descendents are merged with the root parent's.
 - If a feature contains both `ID` and `gene_id` attributes, only the value of `ID` is used as the feature's ID.
-- Features can be filtered during GFF parsing by their `source` and/or `type` columns, and these preferences can be specified in the Run Config file. These are inclusive filters. Only features matching the values specified will be retained for selection and listed in the output counts table. An empty list allows all values. See the [parameters documentation](Parameters.md#filters) for information about specifying these filters.
-- If a filtered feature breaks a feature lineage (that is, features chained via the `Parent` attribute), then the highest non-filtered ancestor is designated the root parent. The lineage is maintained transparently but the filtered feature does not contribute to the domains of selection.
+- If a filtered feature breaks a feature lineage (that is, features chained via the `Parent` attribute), then the highest non-filtered ancestor is designated the root parent. The lineage is maintained transparently but the filtered feature does not contribute to the domains of selection. A feature is considered "filtered" when it fails to match a rule's `Source Filter` **and** `Type Filter`

--- a/tests/unit_test_helpers.py
+++ b/tests/unit_test_helpers.py
@@ -16,10 +16,12 @@ from typing import List
 
 from tiny.rna.configuration import CSVReader, PathsFile
 
-rules_template = [{'Identity': ("Name", "N/A"),
+rules_template = [{'Identity': ("*", "*"),
+                   'Class': '',
+                   'Filter_s': "",
+                   'Filter_t': "",
                    'Strand': "both",
                    'Hierarchy': 0,
-                   'Class': '',
                    'nt5end': "all",
                    'Length': "all",   # A string is expected by FeatureSelector due to support for lists and ranges
                    'Overlap': "partial"}]

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -33,6 +33,8 @@ class CounterTests(unittest.TestCase):
             'Key':       "Class",
             'Value':     "CSR",
             'Class':     "",
+            'Filter_s':  "",
+            'Filter_t':  "",
             'Hierarchy': "1",
             'Strand':    "antisense",
             "nt5end":    '"C,G,U"',  # Needs to be double-quoted due to commas
@@ -46,6 +48,8 @@ class CounterTests(unittest.TestCase):
         self.parsed_feat_rule = [{
             'Identity':  (_row['Key'], _row['Value']),
             'Class':     _row['Class'],
+            'Filter_s':  _row['Filter_s'],
+            'Filter_t':  _row['Filter_t'],
             'Hierarchy': int(_row['Hierarchy']),
             'Strand':    _row['Strand'],
             'nt5end':    _row["nt5end"].upper().translate({ord('U'): 'T'}),

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -30,16 +30,6 @@ inputs:
 
   # Optional inputs
 
-  source_filter:
-    type: string[]?
-    inputBinding:
-      prefix: -sf
-
-  type_filter:
-    type: string[]?
-    inputBinding:
-      prefix: -tf
-
   normalize_by_hits:
     type: string?
     inputBinding:

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -86,8 +86,6 @@ inputs:
   counter_decollapse: boolean?
   counter_stepvector: string?
   counter_all_features: boolean?
-  counter_type_filter: string[]?
-  counter_source_filter: string[]?
   counter_normalize_by_hits: boolean?
 
   # deseq inputs
@@ -210,8 +208,6 @@ steps:
       gff_files: gff_files
       out_prefix: run_name
       all_features: counter_all_features
-      source_filter: counter_source_filter
-      type_filter: counter_type_filter
       normalize_by_hits:
         source: counter_normalize_by_hits
         valueFrom: $(String(self))  # convert boolean -> string

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -657,17 +657,25 @@ class CSVReader(csv.DictReader):
     def check_backward_compatibility(self, header_vals):
         compat_errors = []
         if self.doctype == "Features Sheet":
-            v1_2_0 = {'add': {'source filter', 'type filter'}, 'remove': {'tag'}}
-            if len(header_vals & v1_2_0['add']) != 2:
+            if len(header_vals & {'alias by...', 'feature source'}):
+                compat_errors.append('\n'.join([
+                    "It looks like you're using a Features Sheet from an earlier version of",
+                    "tinyRNA. Feature aliases and GFF files are now defined in the Paths File.",
+                    "Please review the Paths File documentation in Configuration.md, update your",
+                    'Paths File, and remove the "Alias by..." and "Feature Source" columns from',
+                    "your Features Sheet to avoid this error."
+                ]))
+
+            if len(header_vals & {'source filter', 'type filter'}) != 2:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from an earlier version of",
                     "tinyRNA. Source and type filters are now defined in the Features Sheet.",
                     "They are no longer defined in the Run Config. Please review the Stage 1",
                     "section in tiny-count's documentation, then add the new columns",
-                    '"Source Filter" and "Type Filter" to your Features Sheet.'
+                    '"Source Filter" and "Type Filter" to your Features Sheet to avoid this error.'
                 ]))
 
-            if len(header_vals & v1_2_0['remove']):
+            if 'tag' in header_vals:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from a version of tinyRNA",
                     'that offered "tagged counting". The "Tag" header has been repurposed as a feature',

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -38,12 +38,6 @@ def get_args():
 
     # Optional arguments
     optional_args.add_argument('-h', '--help', action="help", help="show this help message and exit")
-    optional_args.add_argument('-sf', '--source-filter', metavar='SOURCE', nargs='*', default=[],
-                               help='Only produce counts for features whose '
-                                    'GFF column 2 matches the source(s) listed')
-    optional_args.add_argument('-tf', '--type-filter', metavar='TYPE', nargs='*', default=[],
-                               help='Only produce counts for features whose '
-                                    'GFF column 3 matches the type(s) listed')
     optional_args.add_argument('-nh', '--normalize-by-hits', metavar='T/F', default='T',
                                help='If T/true, normalize counts by (selected) '
                                     'overlapping feature counts. Default: true.')

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -138,10 +138,9 @@ def load_config(features_csv: str, is_pipeline: bool) -> List[dict]:
 
     rules = list()
 
-    for row in CSVReader(features_csv, "Features Sheet").rows():
-        rule = {col: row[col] for col in ["Tag", "Hierarchy", "Strand", "nt5end", "Length", "Overlap"]}
+    for rule in CSVReader(features_csv, "Features Sheet").rows():
         rule['nt5end'] = rule['nt5end'].upper().translate({ord('U'): 'T'})  # Convert RNA base to cDNA base
-        rule['Identity'] = (row['Key'], row['Value'])                       # Create identity tuple
+        rule['Identity'] = (rule.pop('Key'), rule.pop('Value'))             # Create identity tuple
         rule['Hierarchy'] = int(rule['Hierarchy'])                          # Convert hierarchy to number
         rule['Overlap'] = rule['Overlap'].lower()                           # Built later in ReferenceTables
 
@@ -151,28 +150,27 @@ def load_config(features_csv: str, is_pipeline: bool) -> List[dict]:
     return rules
 
 
-def load_gff_files(paths: PathsFile, libraries: List[dict], args: ReadOnlyDict) -> Dict[str, list]:
+def load_gff_files(paths: PathsFile, libraries: List[dict], rules: List[dict]) -> Dict[str, list]:
     """Retrieves the appropriate file path and alias attributes for each GFF,
     then validates
 
     Args:
-        paths: a loaded PathsFile with
-        libraries: a list of library files, each as a dict with a 'File' key
-        gff_files: a list of gff files, each as a dict with keys `path` and `alias`
-        args: command line arguments passed to GFFValidator for source/type filters
+        paths: a loaded PathsFile with a populated gff_files parameter
+        libraries: libraries parsed from Samples Sheet, each as a dict with a 'File' key
+        rules: selection rules parsed from Features Sheet
 
     Returns:
         gff: a dict of GFF files with lists of alias attribute keys
     """
 
     gff_files = defaultdict(list)
-    screen_alias = ["id"]
+    ignore_alias = ["id"]
 
     # Build dictionary of unique files and allowed aliases
     for gff in paths['gff_files']:
         gff_files[gff['path']].extend(
             alias for alias in gff.get('alias', ())
-            if alias.lower() not in screen_alias
+            if alias.lower() not in ignore_alias
         )
 
     # Remove duplicate aliases (per file), keep original order
@@ -186,7 +184,7 @@ def load_gff_files(paths: PathsFile, libraries: List[dict], args: ReadOnlyDict) 
     # ref_genomes = [map_path(fasta) for fasta in paths['reference_genome_files']]
     # ebwt_prefix = map_path(paths['ebwt'])
 
-    GFFValidator(gff_files, args, alignments=sam_files).validate()
+    GFFValidator(gff_files, rules, alignments=sam_files).validate()
     return gff_files
 
 
@@ -223,7 +221,7 @@ def main():
         paths = PathsFile(args['paths_file'], is_pipeline)
         libraries = load_samples(paths['samples_csv'], is_pipeline)
         selection = load_config(paths['features_csv'], is_pipeline)
-        gff_files = load_gff_files(paths, libraries, args)
+        gff_files = load_gff_files(paths, libraries, selection)
 
         # global for multiprocessing
         global counter

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -168,22 +168,29 @@ class FeatureSelector:
         Precondition: rules_table preserves original row order
         """
 
-        selector_builders = {"Strand": StrandMatch, "nt5end": NtMatch, "Length": NumericalMatch, "Identity": lambda x:x}
+        selector_builders = {
+            "Filter_s": GffSourceMatch,
+            "Filter_t": GffTypeMatch,
+            "Strand": StrandMatch,
+            "nt5end": NtMatch,
+            "Length": NumericalMatch,
+            "Identity": lambda x:x
+        }
 
         for i, row in enumerate(rules_table):
             try:
-                for selector, build_fn in selector_builders.items():
-                    defn = row[selector]
-
+                for selector, defn in row.items():
+                    if selector not in selector_builders:
+                        continue
                     if type(defn) is str and defn.lower().strip() in Wildcard.kwds:
                         row[selector] = Wildcard()
                     elif type(defn) is tuple:
                         row[selector] = tuple(Wildcard() if x.lower().strip() in Wildcard.kwds else x for x in defn)
                     else:
-                        row[selector] = build_fn(defn)
+                        row[selector] = selector_builders[selector](defn)
             except Exception as e:
                 # Append to error message while preserving exception provenance and traceback
-                e.args = (str(e.args[0]) + '\n' + f"Error occurred while processing rule number {i + 2}",)
+                e.args = (str(e.args[0]) + '\n' + f"Error occurred while processing rule number {i + 1}",)
                 raise e.with_traceback(sys.exc_info()[2]) from e
 
         return rules_table

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -499,8 +499,8 @@ class ReferenceTables:
 
         # Perform Stage 1 selection
         matches = self.get_matches(row)
-        # Skip features that lack matches unless all_features is True
-        if not self.all_features and not len(matches):
+        # Skip non-matching rows unless all_features=True
+        if not (len(matches) or self.all_features):
             self.exclude_row(row)
             return
         # Grab the primary key for this feature

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -25,19 +25,11 @@ class GffColumnMatch(frozenset):
 
 
 class GffSourceMatch(GffColumnMatch):
-
-    # def __new__(cls, sources):
-    #     super().__new__(cls, sources)
-    
     def __repr__(self):
         return f'<Sources (col. 2) allowed: "{", ".join(self)}">'
 
 
 class GffTypeMatch(GffColumnMatch):
-
-    # def __new__(cls, sources):
-    #     super().__new__(cls, sources)
-
     def __repr__(self):
         return f'<Types (col. 3) allowed: "{", ".join(self)}">'
 

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -16,6 +16,32 @@ class Wildcard(metaclass=Singleton):
     def __repr__(_): return "<all>"
 
 
+class GffColumnMatch(frozenset):
+    def __new__(cls, targets):
+        tokenized_lowercase = map(str.strip, targets.lower().split(','))
+        unique_non_empty = set(t for t in tokenized_lowercase if t)
+
+        return super().__new__(cls, unique_non_empty)
+
+
+class GffSourceMatch(GffColumnMatch):
+
+    # def __new__(cls, sources):
+    #     super().__new__(cls, sources)
+    
+    def __repr__(self):
+        return f'<Sources (col. 2) allowed: "{", ".join(self)}">'
+
+
+class GffTypeMatch(GffColumnMatch):
+
+    # def __new__(cls, sources):
+    #     super().__new__(cls, sources)
+
+    def __repr__(self):
+        return f'<Types (col. 3) allowed: "{", ".join(self)}">'
+
+
 class StrandMatch:
     """Evaluates BOTH the alignment's strand and the feature's strand for a match
 

--- a/tiny/rna/counter/matching.py
+++ b/tiny/rna/counter/matching.py
@@ -23,6 +23,9 @@ class GffColumnMatch(frozenset):
 
         return super().__new__(cls, unique_non_empty)
 
+    def __contains__(self, column_value):
+        return super().__contains__(column_value.lower())
+
 
 class GffSourceMatch(GffColumnMatch):
     def __repr__(self):

--- a/tiny/templates/features.csv
+++ b/tiny/templates/features.csv
@@ -1,7 +1,7 @@
-Select for...,with value...,Tag,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
-Class,mask,,1,both,all,all,Partial
-Class,miRNA,,2,sense,all,16-22,Full
-Class,piRNA,5pA,2,both,A,24-32,Full
-Class,piRNA,5pT,2,both,T,24-32,Full
-Class,siRNA,,2,both,all,15-22,Full
-Class,unk,,3,both,all,all,Full
+Select for...,with value...,Tag,Source Filter,Type Filter,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
+Class,mask,,,,1,both,all,all,Partial
+Class,miRNA,,,,2,sense,all,16-22,Full
+Class,piRNA,5pA,,,2,both,A,24-32,Full
+Class,piRNA,5pT,,,2,both,T,24-32,Full
+Class,siRNA,,,,2,both,all,15-22,Full
+Class,unk,,,,3,both,all,all,Full

--- a/tiny/templates/paths.yml
+++ b/tiny/templates/paths.yml
@@ -5,8 +5,9 @@
 #
 # Directions:
 #   1. Fill out the Samples Sheet with files to process + naming scheme. [samples.csv]
-#   2. Fill out the Features Sheet with reference files and selection rules [features.csv]
-#   3. Set samples_csv and features_csv to point to these files
+#   2. Fill out the Features Sheet with selection rules [features.csv]
+#   3. Set samples_csv and features_csv (below) to point to these files
+#   4. Add annotation files and per-file alias preferences to gff_files
 #
 ######-------------------------------------------------------------------------------######
 

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -233,13 +233,6 @@ counter_normalize_by_hits: True
 ##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
 counter_decollapse: False
 
-##-- Only parse GFF lines that match these values on column 2. [] is wildcard --##
-counter_source_filter: []
-
-##-- Only parse GFF lines that match these values on column 3. [] is wildcard --##
-##-- If source AND type filters are given, a line must match both to be included --##
-counter_type_filter: []
-
 ##-- Select the StepVector implementation that is used. Options: HTSeq or Cython --##
 counter_stepvector: 'Cython'
 


### PR DESCRIPTION
**Config File Changes:**
The `counter_source_filter` and `counter_type_filter` have been moved out of the Run Config and into the Features Sheet. This means that `Source/Type Filters` are specific to their rule/row. They have been absorbed into Stage 1 selection, so we now say the targets of Stage 1 selection are GFF columns 2, 3, and 9.

**Command line argument changes:**
The `--source-filter` and `--type-filter` arguments have been removed from tiny-count.

**Codebase improvements:**
If the Features Sheet contains column headers from a previous version of tinyRNA, a helpful error message is produced that lets the user know what changed, where to read about it, and what to do to make the error go away. This is better than the generic missing/unknown column header that would otherwise be produced. This is true in both pipeline and standalone runs.

**Misc. changes:**
GFFValidator applies the Source and Type Filters before validation, as it had before, but rather than using a fully-built rule table for evaluation, it instead uses a minimal ruleset containing only the filters. This was a performance-oriented change. The ruleset is a single rule containing all specified terms for both filters regardless of the number of rules at input.