### PR TITLE
GFFValidator: adding support for gzipped reference genome files

### DIFF
--- a/tiny/rna/collapser.py
+++ b/tiny/rna/collapser.py
@@ -8,20 +8,17 @@ are available by request.
 
 import argparse
 import builtins
-import gzip
 import os
 
 from collections import Counter
-from functools import partial
 from typing import Tuple, Iterable
+
+from tiny.rna.util import gzip_open as gz_f
 
 try:
     from _collections import _count_elements  # Load Counter's C helper function if it is available
 except ImportError:
     from collections import _count_elements   # Slower mapping[elem] = mapping.get(elem,default_val)+1
-
-# The GZIP read/write interface used by seq_counter() and seq2fasta()
-gz_f = partial(gzip.GzipFile, compresslevel=6, fileobj=None, mtime=0)
 
 
 def get_args() -> 'argparse.NameSpace':

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -213,10 +213,12 @@ class GFFValidator:
 
         genome_chroms = set()
         for fasta in genome_fastas:
-            if not os.path.isfile(fasta): continue
-
-            _, ext = os.path.splitext(fasta)
-            file_if = gzip_open if ext == '.gz' else open
+            if not os.path.isfile(fasta):
+                continue
+            elif fasta.endswith('.gz'):
+                file_if = gzip_open
+            else:
+                file_if = open
 
             with file_if(fasta, 'rb') as f:
                 for line in f:

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -1,11 +1,12 @@
 import functools
 import subprocess
 import sys
+import os
 
 from collections import Counter, defaultdict
 
-from tiny.rna.util import sorted_natural
 from tiny.rna.counter.hts_parsing import parse_gff, ReferenceTables
+from tiny.rna.util import sorted_natural, gzip_open
 
 
 class ReportFormatter:
@@ -198,7 +199,9 @@ class GFFValidator:
 
         genome_chroms = set()
         for fasta in genome_fastas:
-            with open(fasta, 'rb') as f:
+            _, ext = os.path.splitext(fasta)
+            file_if = gzip_open if ext == '.gz' else open
+            with file_if(fasta, 'rb') as f:
                 for line in f:
                     if line[0] == ord('>'):
                         genome_chroms.add(line[1:].strip().decode())

--- a/tiny/rna/util.py
+++ b/tiny/rna/util.py
@@ -1,6 +1,7 @@
 import argparse
 import functools
 import textwrap
+import gzip
 import time
 import os
 import re
@@ -94,3 +95,7 @@ def sorted_natural(lines, reverse=False):
     convert = lambda text: int(text) if text.isdigit() else text.lower()
     alphanum_key = lambda key: [convert(c) for c in re.split(r'(\d+)', key)]
     return sorted(lines, key=alphanum_key, reverse=reverse)
+
+
+# File IO interface for reading and writing Gzip files
+gzip_open = functools.partial(gzip.GzipFile, compresslevel=6, fileobj=None, mtime=0)


### PR DESCRIPTION
GFFValidator will now validate chromosomes using gzipped reference genome FASTAs (if appropriate), and will no longer produce a warning under these circumstances