### PR TITLE
Version 1.2 prep: allow changes in Paths File between resume runs

### DIFF
--- a/tiny/cwl/tools/tiny-plot.cwl
+++ b/tiny/cwl/tools/tiny-plot.cwl
@@ -38,7 +38,7 @@ inputs:
       prefix: -ss
     doc: "The summary stats csv from Counter"
 
-  len_dist:
+  len_dist_tables:
     type: File[]
     inputBinding:
       prefix: -len

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -243,7 +243,7 @@ steps:
       raw_counts: counter/feature_counts
       rule_counts: counter/rule_counts
       summ_stats: counter/summary_stats
-      len_dist:
+      len_dist_tables:
         source: [ counter/mapped_nt_len_dist, counter/assigned_nt_len_dist ]
         linkMerge: merge_flattened
       len_dist_min:

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -390,10 +390,14 @@ class PathsFile(ConfigBase):
         - Chained assignments can produce unexpected results.
     """
 
+    # Parameter types
     required = ('samples_csv', 'features_csv', 'gff_files')
     single =   ('samples_csv', 'features_csv', 'plot_style_sheet', 'adapter_fasta')
     groups =   ('reference_genome_files', 'gff_files')
     prefix =   ('ebwt', 'run_directory', 'tmp_directory')
+
+    # Parameters that need to be held constant between resume runs for analysis integrity
+    resume_forbidden = ('samples_csv', 'run_directory', 'ebwt', 'reference_genome_files')
 
     def __init__(self, file: str, in_pipeline=False):
         super().__init__(file)

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from glob import glob
 
-from tiny.rna.configuration import ConfigBase, timestamp_format
+from tiny.rna.configuration import ConfigBase, timestamp_format, PathsFile
 
 
 class ResumeConfig(ConfigBase, ABC):
@@ -36,6 +36,9 @@ class ResumeConfig(ConfigBase, ABC):
         self.dt = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         self.entry_inputs = entry_inputs
         self.steps = steps + [f"organize_{s}" for s in steps]
+
+        self.paths = self.load_paths_config()
+        self.assimilate_paths_file()
 
         self._create_truncated_workflow()
         self._rebuild_entry_inputs()
@@ -85,6 +88,20 @@ class ResumeConfig(ConfigBase, ABC):
             wf_inputs[new_input['var']] = new_input['type']
             # Update WorkflowStepInputs (entry step)
             wf_steps[self.steps[0]]['in'][param] = new_input['var']
+
+    def load_paths_config(self):
+        """Constructs a sub-configuration object containing workflow file preferences"""
+        paths_file_path = self.from_here(self['paths_config'])
+        return PathsFile(paths_file_path)
+
+    def assimilate_paths_file(self):
+        """Updates the processed workflow with resume-safe Paths File parameters"""
+        for key in [*PathsFile.single, *PathsFile.groups]:
+            if key in PathsFile.resume_forbidden: continue
+            self[key] = self.paths.as_cwl_file_obj(key)
+        for key in PathsFile.prefix:
+            if key in PathsFile.resume_forbidden: continue
+            self[key] = self.paths[key]
 
     def _add_timestamps(self, steps):
         """Differentiates resume-run output subdirs by adding a timestamp to them"""

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -172,7 +172,7 @@ class ResumePlotterConfig(ResumeConfig):
             'raw_counts': {'var': "resume_raw", 'type': "File"},
             'rule_counts': {'var': "resume_rule", 'type': "File"},
             'summ_stats': {'var': "resume_stat", 'type': "File"},
-            'len_dist': {'var': "resume_len_dist", 'type': "File[]"}
+            'len_dist_tables': {'var': "resume_len_dist", 'type': "File[]"}
         }
 
         dge_outputs = {


### PR DESCRIPTION
This PR allows for certain keys in the Paths File to be changed between resume runs. This addresses a bug where changes to the parameters in the Paths Sheet aren't integrated into the processed Run Config when executing resume runs. This PR also addresses a notice (not warning or error) issued by cwltool regarding similar parameter names in tiny-plot.cwl