### PR TITLE
tiny-plot: sanity improvements in scatter plot tick labels

### DIFF
--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -458,11 +458,10 @@ class plotterlib:
     def cache_ticks(self, axis: mpl.axis.Axis, name: str):
         """Cache major and minor tick objects, which contain expensive data"""
 
-        if not self.prefs['cache_scatter_ticks']: return
-
-        for type in ["major", "minor"]:
-            self.dge_scatter_tick_cache[f"{name}_{type}_loc"] = getattr(axis, type).locator
-            self.dge_scatter_tick_cache[f"{name}_{type}_tix"] = getattr(axis, f"{type}Ticks")
+        if self.prefs.get('cache_scatter_ticks', True):
+            for type in ["major", "minor"]:
+                self.dge_scatter_tick_cache[f"{name}_{type}_loc"] = getattr(axis, type).locator
+                self.dge_scatter_tick_cache[f"{name}_{type}_tix"] = getattr(axis, f"{type}Ticks")
 
     def restore_ticks(self, ax: plt.Axes, axis: str):
         """Restore tick objects from previous render"""

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -36,7 +36,7 @@ from abc import ABC, abstractmethod
 
 class plotterlib:
 
-    def __init__(self, user_style_sheet):
+    def __init__(self, user_style_sheet, **prefs):
 
         self.debug = self.is_debug_mode()
         if self.debug:
@@ -46,6 +46,7 @@ class plotterlib:
         # Set global plot style once
         plt.style.use(user_style_sheet)
 
+        self.prefs = prefs
         self.subplot_cache = {}
         self.dge_scatter_tick_cache = {}
 
@@ -457,6 +458,8 @@ class plotterlib:
     def cache_ticks(self, axis: mpl.axis.Axis, name: str):
         """Cache major and minor tick objects, which contain expensive data"""
 
+        if not self.prefs['cache_scatter_ticks']: return
+
         for type in ["major", "minor"]:
             self.dge_scatter_tick_cache[f"{name}_{type}_loc"] = getattr(axis, type).locator
             self.dge_scatter_tick_cache[f"{name}_{type}_tix"] = getattr(axis, f"{type}Ticks")
@@ -620,6 +623,9 @@ class plotterlib:
 class CacheBase(ABC):
     @abstractmethod
     def get(self): pass
+
+    def __del__(self):
+        plt.close(self.fig)
 
 
 class ClassChartCache(CacheBase):

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -383,8 +383,8 @@ class plotterlib:
         """Produces a list of locations for major ticks for the given view limit"""
 
         ax_min, ax_max = min(view_lims), max(view_lims)
-        floor, ceil, log2 = math.floor, math.ceil, np.log2
-        locs = [2 ** x for x in range(floor(log2(ax_min)), ceil(log2(ax_max)))]
+        ceil, log2 = math.ceil, np.log2
+        locs = [2 ** x for x in range(ceil(log2(ax_min)), ceil(log2(ax_max)))]
         return locs, ax_min, ax_max
 
     def set_scatter_ticks(self, ax: plt.Axes, minor_ticks=False):
@@ -402,7 +402,8 @@ class plotterlib:
 
         for axis in [ax.xaxis, ax.yaxis]:
             # Only display every nth major tick label
-            ticks_displayed, last_idx = self.every_nth_label(axis, 3)
+            n = int(np.log2(len(major_locs)) - 1)
+            ticks_displayed, last_idx = self.every_nth_label(axis, n)
 
             if minor_ticks:
                 axis.set_minor_locator(tix.LogLocator(
@@ -410,7 +411,7 @@ class plotterlib:
                     numticks=self.get_min_LogLocator_numticks(axis),
                     subs=np.log2(np.linspace(2 ** 2, 2 ** 4, 10))[:-1]))
 
-            min_tick = 2 ** (np.log2(ax_min)+1)
+            min_tick = ax_min
             max_tick = major_locs[last_idx]
             self.set_tick_bounds(axis, min_tick=min_tick, max_tick=max_tick, minor=minor_ticks)
             self.cache_ticks(axis, axis.__name__)
@@ -428,16 +429,6 @@ class plotterlib:
             else:
                 ticks_displayed.append(tick)
                 last_idx = i
-
-        # Hide tick labels in the lower left corner, regardless
-        major_ticks[0].label1.set_visible(False)
-
-        # If the last tick label on the x-axis will extend past the plot space,
-        # then hide it and its corresponding tick on the y-axis
-        if axis.__name__ == "xaxis" and axis.get_tick_space() == len(ticks_displayed):
-            major_ticks[last_idx].label1.set_visible(False)
-            yaxis = axis.axes.yaxis
-            yaxis.get_major_ticks()[last_idx].label1.set_visible(False)
 
         return ticks_displayed, last_idx
 


### PR DESCRIPTION
The routine for placing scatter plot tick labels is now more robust when the plotted range is very small or very large. "Every other _n_" label placement now adjusts to the plot window rather than being a fixed _n_ = 3. Labels are no longer suppressed at the origin; this was originally done when we were using exponent labels which are much wider. Labels at the upper end of the axis are placed more liberally. All in all, these changes produce tick labels with more comfortable density under a wider range of plot window sizes.

This is demonstrated in the below animation, which uses a rolling, expanding window:
![sane_ticks_2_small](https://user-images.githubusercontent.com/63317/209401063-00295fce-c5b1-4f52-8013-d26f7f2dfd9d.gif)

Closes #265 