### PR TITLE
tiny-count: support for sequence-based read counting

### DIFF
--- a/START_HERE/paths.yml
+++ b/START_HERE/paths.yml
@@ -7,7 +7,7 @@
 #   1. Fill out the Samples Sheet with files to process + naming scheme. [samples.csv]
 #   2. Fill out the Features Sheet with selection rules [features.csv]
 #   3. Set samples_csv and features_csv (below) to point to these files
-#   4. Add annotation files and per-file alias preferences to gff_files
+#   4. Add annotation files and per-file alias preferences to gff_files (optional)
 #
 ######-------------------------------------------------------------------------------######
 

--- a/tests/testdata/config_files/paths.yml
+++ b/tests/testdata/config_files/paths.yml
@@ -7,7 +7,7 @@
 #   1. Fill out the Samples Sheet with files to process + naming scheme. [samples.csv]
 #   2. Fill out the Features Sheet with selection rules [features.csv]
 #   3. Set samples_csv and features_csv (below) to point to these files
-#   4. Add annotation files and per-file alias preferences to gff_files
+#   4. Add annotation files and per-file alias preferences to gff_files (optional)
 #
 ######-------------------------------------------------------------------------------######
 

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -231,40 +231,6 @@ class CounterTests(unittest.TestCase):
 
         self.assertEqual(ruleset[0]['nt5end'], 'T')
 
-    """Does load_gff_files properly screen for "ID" alias attributes?"""
-
-    def test_load_gff_files_id_alias_attr(self):
-        config = helpers.make_paths_file()
-        config['gff_files'] = [{'path': "/irrelevant", 'alias': ['ID']}]
-
-        # Patch GFFValidator so that it isn't called (not relevant)
-        with patch('tiny.rna.counter.counter.GFFValidator'):
-            gff_files = counter.load_gff_files(config, [], {})
-
-        expected = {"/irrelevant": []}
-        self.assertDictEqual(gff_files, expected)
-
-    """Does load_gff_files merge aliases if the same GFF file is listed more than once? 
-    Are duplicates also removed and original order preserved?"""
-
-    def test_load_gff_files_merge_alias_attr(self):
-        config = helpers.make_paths_file()
-        config['gff_files'] = [
-            {'path': "/same/path", 'alias': ['attr1', 'attr2']},
-            {'path': "/same/path", 'alias': ['attr1', 'attrN']},
-            {'path': "/different/path", 'alias': ['attr3']}
-        ]
-
-        # Patch GFFValidator so that it isn't called (not relevant)
-        with patch('tiny.rna.counter.counter.GFFValidator'):
-            gff_files = counter.load_gff_files(config, [], {})
-
-        expected = {
-            "/same/path": ['attr1', 'attr2', 'attrN'],
-            "/different/path": ['attr3']
-        }
-
-        self.assertDictEqual(gff_files, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests_stepvector.py
+++ b/tests/unit_tests_stepvector.py
@@ -10,7 +10,7 @@ class StepVectorTests(unittest.TestCase):
 
     def test_genomicarray_with_cython_stepvec(self):
         # Patch the StepVector reference in the HTSeq module and use a GenomicArray
-        # instead of a GenomicArrayOfSets, just as we do in ReferenceTables
+        # instead of a GenomicArrayOfSets, just as we do in reference parsers
         setattr(HTSeq.StepVector, 'StepVector', StepVector)
         gas = HTSeq.GenomicArray('auto', stranded=False)
 

--- a/tests/unit_tests_validation.py
+++ b/tests/unit_tests_validation.py
@@ -299,7 +299,7 @@ class SamSqValidatorTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.syntax_header = "Every SAM file must have complete @SQ headers with SN and LN\n" \
-                             "fields when counting in non-genomic mode.\n"
+                             "fields when performing sequence-based counting.\n"
 
         self.identifier_header = "Sequence identifiers must be unique and have consistent length definitions.\n"
     

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -2,6 +2,7 @@ import ruamel.yaml
 import argparse
 import shutil
 import errno
+import time
 import sys
 import csv
 import os
@@ -581,11 +582,19 @@ class PathsFile(ConfigBase):
             gff_files[file] = sorted(set(alias), key=alias.index)
 
         if not len(gff_files) and not self.in_pipeline:
-            print("No GFF files were specified in {selfname} so "
-                  "reads will be counted in non-genomic mode."
-                  .format(selfname=self.basename))
+            self.print_sequence_counting_notice()
 
         return dict(gff_files)
+
+    def print_sequence_counting_notice(self):
+        print("No GFF files were specified in {selfname}.\n"
+              "Reads will be quantified by sequence "
+              "rather than by feature."
+              .format(selfname=self.basename))
+
+        for s in reversed(range(6)):
+            print(f"Proceeding in {s}s", end='\r')
+            time.sleep(1)
 
     # Override
     def append_to(self, key: str, val: Any):

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -449,7 +449,7 @@ class PathsFile(ConfigBase):
     """
 
     # Parameter types
-    required = ('samples_csv', 'features_csv', 'gff_files')
+    required = ('samples_csv', 'features_csv')
     single =   ('samples_csv', 'features_csv', 'plot_style_sheet', 'adapter_fasta')
     groups =   ('reference_genome_files', 'gff_files')
     prefix =   ('ebwt', 'run_directory', 'tmp_directory')
@@ -508,9 +508,10 @@ class PathsFile(ConfigBase):
             "The following parameters are required in {selfname}: {params}" \
             .format(selfname=self.basename, params=', '.join(self.required))
 
-        assert any(gff.get('path') for gff in self['gff_files']), \
-            "At least one GFF file path must be specified under gff_files in {selfname}" \
-            .format(selfname=self.basename)
+        if not any(gff.get('path') for gff in self['gff_files']):
+            print("No GFF files were specified in {selfname} so "
+                  "reads will be counted in non-genomic mode."
+                  .format(selfname=self.basename))
 
         # Some entries in Paths File are omitted from tiny-count's working directory during
         #  pipeline runs. There is no advantage to checking file existence here vs. in load_*
@@ -526,6 +527,7 @@ class PathsFile(ConfigBase):
         for key in self.groups:
             for entry in self[key]:
                 if isinstance(entry, dict): entry = entry['path']
+                if not entry: continue
                 assert os.path.isfile(entry), \
                     "The following file provided under {key} in {selfname} could not be found:\n\t{file}" \
                     .format(key=key, selfname=self.basename, file=entry)

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -4,7 +4,7 @@ import sys
 from collections import defaultdict
 from typing import List, Tuple, Set, Dict, Mapping
 
-from tiny.rna.counter.hts_parsing import SAM_reader, ReferenceTables, NonGenomicAnnotations
+from tiny.rna.counter.hts_parsing import SAM_reader, ReferenceFeatures, ReferenceSeqs
 from .statistics import LibraryStats
 from .matching import *
 
@@ -32,12 +32,12 @@ class FeatureCounter:
         self.sam_reader = SAM_reader(**prefs)
         self.selector = FeatureSelector(selection_rules, self.stats, **prefs)
 
-        if isinstance(references, ReferenceTables):
+        if isinstance(references, ReferenceFeatures):
             self.mode = "genomic"
-        elif isinstance(references, NonGenomicAnnotations):
+        elif isinstance(references, ReferenceSeqs):
             self.mode = "non-genomic"
         else:
-            raise TypeError("Expected ReferenceTables or NonGenomicAnnotations, got %s" % type(references))
+            raise TypeError("Expected ReferenceFeatures or ReferenceSeqs, got %s" % type(references))
 
         Features(*references.get(self.selector))
         self.prefs = prefs
@@ -84,7 +84,7 @@ class FeatureSelector:
     Two sources of data serve as targets for selection: feature attributes (sourced from
     input GFF files), and sequence attributes (sourced from input SAM files).
     All candidate features are assumed to have matched at least one Identity selector,
-    as determined by hts_parsing.ReferenceTables.get_matches_and_classes()
+    as determined by hts_parsing.ReferenceFeatures.get_matches_and_classes()
 
     The first round of selection was performed during GFF parsing.
 
@@ -205,7 +205,7 @@ class FeatureSelector:
 
         Unlike build_selectors() and build_inverted_identities(), this function
         is not called at construction time. Instead, it is called when finalizing
-        match-tuples in ReferenceTables. This is because interval selectors are
+        match-tuples in reference parsers. This is because interval selectors are
         created for each feature (requiring start/stop/strand to be known) for
         each of the feature's identity matches (each match-tuple).
 

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -33,9 +33,9 @@ class FeatureCounter:
         self.selector = FeatureSelector(selection_rules, self.stats, **prefs)
 
         if isinstance(references, ReferenceFeatures):
-            self.mode = "genomic"
+            self.mode = "by feature"
         elif isinstance(references, ReferenceSeqs):
-            self.mode = "non-genomic"
+            self.mode = "by sequence"
         else:
             raise TypeError("Expected ReferenceFeatures or ReferenceSeqs, got %s" % type(references))
 

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -236,7 +236,7 @@ def infer_strandedness(sam_file: str, intervals: dict) -> str:
 
     Args:
         sam_file: the path of the SAM file to evaluate
-        intervals: the intervals instance attribute of ReferenceTables, populated by .get()
+        intervals: the intervals instance attribute of ReferenceFeatures, populated by .get()
     """
 
     unstranded = HTSeq.GenomicArrayOfSets("auto", stranded=False)
@@ -419,7 +419,9 @@ class CaseInsensitiveAttrs(Dict[str, tuple]):
         raise NotImplementedError(f"CaseInsensitiveAttrs does not support {stack()[1].function}")
 
 
-class AnnotationParsing(ABC):
+class ReferenceBase(ABC):
+    """The base class for reference parsers"""
+
     def __init__(self, **prefs):
         self.stepvector = prefs.get('stepvector', 'HTSeq')
         self.feats = self._init_genomic_array()
@@ -501,7 +503,8 @@ AliasTable = DefaultDict[str, Tuple[str]]
 TagTable = DefaultDict[str, Set[Tuple[str, str]]]
 GenomicArray = HTSeq.GenomicArrayOfSets
 
-class ReferenceTables(AnnotationParsing):
+
+class ReferenceFeatures(ReferenceBase):
     """A GFF parser which builds feature, alias, and class reference tables
 
     Discontinuous features are supported, and comma-separated attribute values (GFF3 column 9)
@@ -514,7 +517,7 @@ class ReferenceTables(AnnotationParsing):
     Children of the root ancestor are otherwise not stored in the reference tables.
 
     Match-tuples are created for each Features Sheet rule which matches a feature's attributes.
-    They are structured as (rank, rule, overlap). "Rank" is the heirarchy value of the matching
+    They are structured as (rank, rule, overlap). "Rank" is the hierarchy value of the matching
     rule, "rule" is the index of that rule in FeatureSelector's rules table, and "overlap" is the
     IntervalSelector per the rule's overlap requirements.
 
@@ -582,7 +585,7 @@ class ReferenceTables(AnnotationParsing):
         """Returns the highest feature ID in the ancestral tree which passed stage 1 selection.
         The original feature ID is returned if there are no valid ancestors."""
 
-        # Descend tree until the descendent is found in the matches table
+        # Descend tree until the descendant is found in the matches table
         # This is because ancestor feature(s) may have been filtered
         for ancestor in lineage[::-1]:
             if self.was_matched(ancestor):
@@ -761,7 +764,7 @@ class ReferenceTables(AnnotationParsing):
         return row.source in rule['Filter_s'] and row.type in rule['Filter_t']
 
 
-class NonGenomicAnnotations(AnnotationParsing):
+class ReferenceSeqs(ReferenceBase):
 
     def __init__(self, reference_seqs, **prefs):
         super().__init__(**prefs)

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -796,7 +796,7 @@ class NonGenomicAnnotations(AnnotationParsing):
 
         # Features are classified in Reference Tables (Stage 1 selection)
         # For compatibility, use the seq_id with an empty classifier (index 1)
-        tagged_id = (seq_id,)
+        tagged_id = (seq_id, '')
         self.tags[seq_id] = {tagged_id}
 
         for strand in ('+', '-'):

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -772,7 +772,6 @@ class ReferenceSeqs(ReferenceBase):
         self.alias = {}
         self.tags = {}
 
-    @report_execution_time("Non-genomic annotations parsing")
     def get(self, selector):
         self.selector = selector
         match_tuples = self.get_matches()
@@ -785,7 +784,7 @@ class ReferenceSeqs(ReferenceBase):
         return self.feats, aliases, self.tags
 
     def get_matches(self):
-        """Stage 1 selection is skipped in non-genomic counting.
+        """Stage 1 selection is skipped in sequence-based counting.
         Simply build match_tuples for all rules. These will be used
         uniformly in each reference sequence's feature_record_tuple"""
 

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -87,7 +87,7 @@ class GFFValidator:
     }
 
     def __init__(self, gff_files, rules, ebwt=None, genomes=None, alignments=None):
-        self.ReferenceTables = ReferenceTables(gff_files, None)
+        self.ReferenceTables = ReferenceTables(gff_files)
         self.column_filters = self.build_column_filters(rules)
         self.report = ReportFormatter(self.targets)
         self.chrom_set = set()

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -61,14 +61,19 @@ class ReportFormatter:
 
         lines = []
         for key, val in mapping.items():
-            if not val: continue
             key_header = f"{indent}{self.key_mapper.get(key, key)}: "
             if isinstance(val, dict):
                 lines.append(key_header)
-                lines.extend(self.recursive_indent(val, indent + '\t'))
+                if len(val):
+                    lines.extend(self.recursive_indent(val, indent + '\t'))
+                else:
+                    lines.append(indent + "\t" + "{ NONE }")
             elif isinstance(val, (list, set)):
                 lines.append(key_header)
-                lines.extend([indent + '\t' + line for line in map(str, val)])
+                if len(val):
+                    lines.extend([indent + '\t' + line for line in map(str, val)])
+                else:
+                    lines.append(indent + "\t" + "[ NONE ]")
             else:
                 lines.append(key_header + str(val))
         return lines

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -6,7 +6,7 @@ import os
 from collections import Counter, defaultdict
 from typing import List, Dict
 
-from tiny.rna.counter.hts_parsing import parse_gff, ReferenceTables, SAM_reader
+from tiny.rna.counter.hts_parsing import parse_gff, ReferenceFeatures, SAM_reader
 from tiny.rna.counter.features import FeatureSelector
 from tiny.rna.util import sorted_natural, gzip_open, report_execution_time
 
@@ -92,7 +92,7 @@ class GFFValidator:
     }
 
     def __init__(self, gff_files, rules, ebwt=None, genomes=None, alignments=None):
-        self.ReferenceTables = ReferenceTables(gff_files)
+        self.ReferenceFeatures = ReferenceFeatures(gff_files)
         self.column_filters = self.build_column_filters(rules)
         self.report = ReportFormatter(self.targets)
         self.chrom_set = set()
@@ -120,13 +120,13 @@ class GFFValidator:
     def validate_gff_row(self, row, issues, file):
         # Skip definitions of whole chromosomes and obey source/type filters
         if row.type.lower() == "chromosome": return
-        if not self.ReferenceTables.column_filter_match(row, self.column_filters): return
+        if not self.ReferenceFeatures.column_filter_match(row, self.column_filters): return
 
         if row.iv.strand not in ('+', '-'):
             issues['strand'][file] += 1
 
         try:
-            self.ReferenceTables.get_feature_id(row)
+            self.ReferenceFeatures.get_feature_id(row)
         except:
             issues['ID attribute'][file] += 1
 

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -241,7 +241,7 @@ class GFFValidator:
         for file in sam_files:
             file_chroms = set()
             with open(file, 'rb') as f:
-                for line, i in zip(f, range(subset_size)):
+                for i, line in zip(range(subset_size), f):
                     if line[0] == ord('@'): continue
                     file_chroms.add(line.split(b'\t')[2].strip().decode())
                     if i % 10000 == 0 and len(file_chroms & self.chrom_set): break

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -295,7 +295,7 @@ class GFFValidator:
 
 
 class SamSqValidator:
-    """Validates @SQ headers for tiny-count's non-genomic counting mode"""
+    """Validates @SQ headers for tiny-count's sequence-based counting mode"""
 
     targets = {
         "inter sq": "Sequence identifiers with inconsistent lengths",
@@ -310,7 +310,6 @@ class SamSqValidator:
         self.reference_seqs = {}
         self.sq_headers = {}
 
-    @report_execution_time("Non-genomic annotations validation")
     def validate(self):
         print("Validating sequence identifiers in SAM files...")
         self.read_sq_headers()
@@ -391,7 +390,7 @@ class SamSqValidator:
             report['incomplete sq'] = sorted_natural(incomplete)
 
         header = "Every SAM file must have complete @SQ headers with SN and LN\n" \
-                 "fields when counting in non-genomic mode.\n"
+                 "fields when performing sequence-based counting.\n"
         self.report.add_error_section(header, report)
 
     def generate_identifier_report(self, duplicate, ambiguous):

--- a/tiny/rna/resume.py
+++ b/tiny/rna/resume.py
@@ -91,9 +91,11 @@ class ResumeConfig(ConfigBase, ABC):
             wf_steps[self.steps[0]]['in'][param] = new_input['var']
 
     def load_paths_config(self):
-        """Constructs a sub-configuration object containing workflow file preferences"""
-        paths_file_path = self.from_here(self['paths_config'])
-        return PathsFile(paths_file_path)
+        """Returns a PathsFile object and updates keys related to the Paths File path"""
+
+        self['paths_config'] = self.from_here(self['paths_config'])
+        self['paths_file'] = self.cwl_file(self['paths_config'])
+        return PathsFile(self['paths_config'])
 
     def assimilate_paths_file(self):
         """Updates the processed workflow with resume-safe Paths File parameters"""

--- a/tiny/templates/paths.yml
+++ b/tiny/templates/paths.yml
@@ -7,7 +7,7 @@
 #   1. Fill out the Samples Sheet with files to process + naming scheme. [samples.csv]
 #   2. Fill out the Features Sheet with selection rules [features.csv]
 #   3. Set samples_csv and features_csv (below) to point to these files
-#   4. Add annotation files and per-file alias preferences to gff_files
+#   4. Add annotation files and per-file alias preferences to gff_files (optional)
 #
 ######-------------------------------------------------------------------------------######
 


### PR DESCRIPTION
tiny-count can now perform sequence-based counting as an alternative to feature-based counting. This is useful to users who don't have GFF annotations for their experiment, or users who want to count reads against a set of known sequences.

tiny-count automatically switches to this counting mode when a user's Paths File doesn't have any GFFs listed.
tinyRNA no longer requires GFF files at pipeline startup.

### Technical Details
In sequence-based counting mode, Stage 1 selectors cannot be evaluated and are therefore ignored (`Select for...`, `with value...`, `Classify as...`, `Source Filter`, and `Type Filter` ). Stage 2 and Stage 3 are evaluated as they would be for feature-based counting.

In sequence-based counting mode, "feature" intervals are defined by the `@SQ` headers of input SAM files. These headers only define a sequence identifier, which is used as the "Feature ID", and a length for each sequence. These headers correspond to the reference fasta that the reads were aligned against (in bowtie's case, this is the fasta input to bowtie-build). Reads are counted for alignments to each of these reference sequences on both strands. Unlike in feature-based counting, _all_ rules are evaluated for all reference sequences in Stages 2 and 3.

SAM `@SQ` headers are evaluated to ensure that they are present in each file, they contain the required fields, no identifier appears more than once in each file, and identifiers have a consistent length indicated in the headers of all input SAM files. 

Closes #277 