### PR TITLE
tiny-plot: legend sorted by natural order, other reliability improvements

### DIFF
--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -402,7 +402,9 @@ def scatter_by_dge_class(counts_avg_df, dges, output_prefix, view_lims, include=
     """
 
     counts_avg_df, dges = filter_dge_classes(counts_avg_df, dges, include, exclude)
-    if counts_avg_df.empty or dges.empty: return
+    if counts_avg_df.empty or dges.empty:
+        print('ERROR: No classes passed filtering. Skipping scatter_by_dge_class.', file=sys.stderr)
+        return
 
     uniq_classes = pd.unique(counts_avg_df.index.get_level_values(1))
     class_colors = aqplt.assign_class_colors(uniq_classes)
@@ -442,6 +444,7 @@ def scatter_by_dge(counts_avg_df, dges, output_prefix, view_lims, pval=0.05):
     """
 
     if counts_avg_df.empty or dges.empty:
+        print('ERROR: Received empty counts data. Skipping scatter_by_dge.', file=sys.stderr)
         return
 
     for pair in dges:

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -319,7 +319,10 @@ class plotterlib:
         for line in axes.lines:
             line.set_zorder(len(layers) + 1)
 
-        axes.legend()
+        # Sort the legend with outgroup last while retaining layer order
+        handles = sorted_natural(layers[offset:], key=lambda x: x.get_label())
+        if outgroup: handles.append(layers[0])
+        axes.legend(handles=handles)
 
     @staticmethod
     def assign_class_colors(classes):

--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -33,6 +33,8 @@ from matplotlib.scale import LogTransform
 from typing import Union, Tuple, List, Optional
 from abc import ABC, abstractmethod
 
+from tiny.rna.util import sorted_natural
+
 
 class plotterlib:
 

--- a/tiny/rna/util.py
+++ b/tiny/rna/util.py
@@ -204,7 +204,8 @@ class ReadOnlyDict(dict):
     def __setitem__(self, *_):
         raise RuntimeError("Attempted to modify read-only dictionary after construction.")
 
-def sorted_natural(lines, reverse=False):
+
+def sorted_natural(lines, key=None, reverse=False):
     """Sorts alphanumeric strings with entire numbers considered in the sorting order,
     rather than the default behavior which is to sort by the individual ASCII values
     of the given number. Returns a sorted copy of the list, just like sorted().
@@ -213,7 +214,8 @@ def sorted_natural(lines, reverse=False):
     some time. Strange that there isn't something in the standard library for this."""
 
     convert = lambda text: int(text) if text.isdigit() else text.lower()
-    alphanum_key = lambda key: [convert(c) for c in re.split(r'(\d+)', key)]
+    extract = (lambda data: key(data)) if key is not None else lambda x: x
+    alphanum_key = lambda elem: [convert(c) for c in re.split(r'(\d+)', extract(elem))]
     return sorted(lines, key=alphanum_key, reverse=reverse)
 
 


### PR DESCRIPTION
Scatter plot legends are now sorted by natural order while preserving the intended point layer order (groups with fewest points are plotted on top of the stack).

This PR also includes a number of reliability improvements:
- Fixed an edge case that occurs when the outgroup has all zero counts in one or both conditions. Previously this would result in the outgroup having an entry in the legend without any points being plotted
- Fixed an edge case that occurs when there is no outgroup, and the first group has all zero counts in one or both conditions. Previously this first plotted group wouldn't be recognized as a zero count group, so it would have an entry in the legend without any points being plotted
- Properly handling an empty scatter plot when neither the outgroup nor the other groups can be plotted due to one or both conditions having all zero counts
- Fixed calculation of z-order to avoid group-outgroup conflicts and group-line conflicts. Fortunately the way matplotlib breaks z-order ties always worked out in our favor so this issue was never expressed. Now it's proper.
- Added helpful error messages so that scatter_dge plots aren't silently skipped if inputs are empty (due to class filters, etc.)

Additionally, the `sorted_natural()` function in tiny.rna.util now accepts a `key=` parameter just like Python's `sorted()` does