### PR TITLE
tiny-count: new selector: Mismatches

### DIFF
--- a/START_HERE/features.csv
+++ b/START_HERE/features.csv
@@ -1,7 +1,7 @@
-Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
-Class,mask,masked,,,1,both,all,all,Partial
-Class,miRNA,miRNA,,,2,sense,all,16-24,5' anchored
-Class,piRNA,piRNA-5'A,,,2,both,A,24-32,Nested
-Class,piRNA,piRNA-5'T,,,2,both,T,24-32,Nested
-Class,siRNA,siRNA,,,2,both,all,15-22,Nested
-Class,unk,unknown,,,3,both,all,all,Nested
+Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Overlap,Mismatches,Strand,5' End Nucleotide,Length
+Class,mask,masked,,,1,Partial,,both,all,all
+Class,miRNA,miRNA,,,2,5' anchored,,sense,all,16-24
+Class,piRNA,piRNA-5'A,,,2,Nested,,both,A,24-32
+Class,piRNA,piRNA-5'T,,,2,Nested,,both,T,24-32
+Class,siRNA,siRNA,,,2,Nested,,both,all,15-22
+Class,unk,unknown,,,3,Nested,,both,all,all

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -157,6 +157,7 @@ Selectors in the Features Sheet can be specified as a single value, a list of co
 | `Type Filter`   |    ✓     |   ✓    |  ✓   |       |
 | `Hierarchy`     |          |   ✓    |      |       |
 | `Overlap`       |    ✓     |   ✓    |      |       |
+| `Mismatches`    |    ✓     |   ✓    |  ✓   |   ✓   |
 | `Strand`        |    ✓     |   ✓    |      |       |
 | `5' nt`         |    ✓     |   ✓    |  ✓   |       |
 | `Length`        |    ✓     |   ✓    |  ✓   |   ✓   |

--- a/doc/tiny-count.md
+++ b/doc/tiny-count.md
@@ -87,7 +87,7 @@ selector, M, N
  If these features match rules with `5' anchored` and `3' anchored` overlap selectors, they will be downgraded to `anchored` selectors. Alignments overlapping these features are evaluated for shared start and/or end coordinates, but 5' and 3' ends are not distinguished.
 
 ### Mismatches
-The Mismatch column allows you to place constraints the edit distance, or the number of mismatches and indels, from the alignment to the reference. The Mismatch definition is explicit, i.e., a value of 3 means exactly 3, not 3 or less. Definitions support ranges (e.g., 0-3), lists (e.g., 1, 3), wildcards, and single values.
+The Mismatches column allows you to place constraints the edit distance, or the number of mismatches and indels, from the alignment to the reference. The Mismatch definition is explicit, i.e., a value of 3 means exactly 3, not 3 or less. Definitions support ranges (e.g., 0-3), lists (e.g., 1, 3), wildcards, and single values.
 
 #### Edit Distance Determination
 An alignment's edit distance is determined from its NM tag. If the first alignment in a SAM file doesn't have an NM tag, then the edit distance is calculated from the CIGAR string for all subsequent alignments in the file. If the first alignment has an NM tag then any subsequent alignments missing the tag will have a default edit distance of 0.

--- a/doc/tiny-count.md
+++ b/doc/tiny-count.md
@@ -86,6 +86,12 @@ selector, M, N
 #### Unstranded Features
  If these features match rules with `5' anchored` and `3' anchored` overlap selectors, they will be downgraded to `anchored` selectors. Alignments overlapping these features are evaluated for shared start and/or end coordinates, but 5' and 3' ends are not distinguished.
 
+### Mismatches
+The Mismatch column allows you to place constraints the edit distance, or the number of mismatches and indels, from the alignment to the reference. The Mismatch definition is explicit, i.e., a value of 3 means exactly 3, not 3 or less. Definitions support ranges (e.g., 0-3), lists (e.g., 1, 3), wildcards, and single values.
+
+#### Edit Distance Determination
+An alignment's edit distance is determined from its NM tag. If the first alignment in a SAM file doesn't have an NM tag, then the edit distance is calculated from the CIGAR string for all subsequent alignments in the file. If the first alignment has an NM tag then any subsequent alignments missing the tag will have a default edit distance of 0.
+
 ### Hierarchy
 Each rule must be assigned a hierarchy value. This value is used to sort Stage 2 matches so that matches with smaller hierarchy values take precedence in Stage 3.
 - Each feature can have multiple hierarchy values if it matched more than one rule during Stage 1 selection

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import pysam
 import setuptools
 
 from setuptools.command.install import install
@@ -40,9 +41,10 @@ def get_cython_extension_defs():
     error out if there are build issues, and therefore must be used as optional imports."""
 
     pyx_files = [
-        # (file path, optional)
-        ('tiny/rna/counter/stepvector/_stepvector.pyx', True),
-        ('tests/cython_tests/stepvector/test_cython.pyx', True)
+        # (file path, optional, include)
+        ('tiny/rna/counter/stepvector/_stepvector.pyx', True, []),
+        ('tests/cython_tests/stepvector/test_cython.pyx', True, []),
+        ('tiny/rna/counter/parsing/alignments.pyx', False, pysam.get_include())
     ]
 
     cxx_extension_args = {
@@ -61,9 +63,10 @@ def get_cython_extension_defs():
     return [setuptools.Extension(
                 pyx_filename.replace('./', '').replace('/', '.').rstrip('.pyx'),
                 sources=[pyx_filename],
+                include_dirs=include,
                 optional=optional,
                 **cxx_extension_args)
-            for pyx_filename, optional in pyx_files]
+            for pyx_filename, optional, include in pyx_files]
 
 
 def get_macos_sdk_path():
@@ -120,6 +123,7 @@ setuptools.setup(
     ext_modules=cythonize(
         get_cython_extension_defs(),
         compiler_directives={'language_level': '3'},
+        include_path=pysam.get_include(),
         gdb_debug=False
     ),
     scripts=scripts,

--- a/tests/testdata/config_files/features.csv
+++ b/tests/testdata/config_files/features.csv
@@ -1,7 +1,7 @@
-Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
-Class,mask,,,,1,both,all,all,Partial
-Class,miRNA,,,,2,sense,all,16-22,Nested
-Class,piRNA,5pA,,,2,both,A,24-32,Nested
-Class,piRNA,5pT,,,2,both,T,24-32,Nested
-Class,siRNA,,,,2,both,all,15-22,Nested
-Class,unk,,,,3,both,all,all,Nested
+Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Overlap,Mismatches,Strand,5' End Nucleotide,Length
+Class,mask,,,,1,Partial,0,both,all,all
+Class,miRNA,,,,2,Nested,0,sense,all,16-22
+Class,piRNA,5pA,,,2,Nested,0,both,A,24-32
+Class,piRNA,5pT,,,2,Nested,0,both,T,24-32
+Class,siRNA,,,,2,Nested,0,both,all,15-22
+Class,unk,,,,3,Nested,0,both,all,all

--- a/tests/testdata/counter/validation/sam/sq_headers.sam
+++ b/tests/testdata/counter/validation/sam/sq_headers.sam
@@ -1,0 +1,4 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:I	LN:123
+@SQ	SN:II	LN:456
+@SQ	SN:III

--- a/tests/unit_test_helpers.py
+++ b/tests/unit_test_helpers.py
@@ -22,9 +22,10 @@ rules_template = [{'Identity': ("*", "*"),
                    'Filter_t': "",
                    'Strand': "both",
                    'Hierarchy': 0,
+                   'Overlap': "partial",
+                   'Mismatch': "",
                    'nt5end': "all",
-                   'Length': "all",   # A string is expected by FeatureSelector due to support for lists and ranges
-                   'Overlap': "partial"}]
+                   'Length': "all",}]   # A string is expected by FeatureSelector due to support for lists and ranges
 
 
 def csv_factory(type: str, rows: List[dict], header=()):
@@ -130,7 +131,7 @@ def get_dir_checksum_tree(root_path: str) -> dict:
     return dir_tree
 
 
-def make_parsed_sam_record(Name="0_count=1", Seq="CAAGACAGAGCTTCACCGTTC", Chrom='I', Start=15064570, Strand:bool = True):
+def make_parsed_sam_record(Name="0_count=1", Seq="CAAGACAGAGCTTCACCGTTC", Chrom='I', Start=15064570, Strand=True, NM=0):
     return {
         "Name": Name,
         "Length": len(Seq),
@@ -139,7 +140,8 @@ def make_parsed_sam_record(Name="0_count=1", Seq="CAAGACAGAGCTTCACCGTTC", Chrom=
         "Chrom": Chrom,
         "Start": Start,
         "End": Start + len(Seq),
-        "Strand": Strand
+        "Strand": Strand,
+        "NM": NM
     }
 
 
@@ -186,7 +188,7 @@ def strand_to_bool(strand):
 
 
 # For performing reverse complement
-complement = bytes.maketrans(b'ACGTacgt', b'TGCAtgca')
+complement = str.maketrans('ACGTacgt', 'TGCAtgca')
 
 
 class ShellCapture:

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -36,10 +36,11 @@ class CounterTests(unittest.TestCase):
             'Filter_s':  "",
             'Filter_t':  "",
             'Hierarchy': "1",
+            'Overlap':   "Partial",
+            'Mismatch':  "",
             'Strand':    "antisense",
             "nt5end":    '"C,G,U"',  # Needs to be double-quoted due to commas
             'Length':    "all",
-            'Overlap':   "Partial"
         }
 
         # Represents the parsed Features Sheet row above
@@ -51,10 +52,11 @@ class CounterTests(unittest.TestCase):
             'Filter_s':  _row['Filter_s'],
             'Filter_t':  _row['Filter_t'],
             'Hierarchy': int(_row['Hierarchy']),
+            'Overlap':   _row['Overlap'].lower(),
+            'Mismatch':  _row['Mismatch'],
             'Strand':    _row['Strand'],
             'nt5end':    _row["nt5end"].upper().translate({ord('U'): 'T'}),
             'Length':    _row['Length'],
-            'Overlap':   _row['Overlap'].lower()
         }]
 
         # Represents an unparsed Samples Sheet row

--- a/tests/unit_tests_features.py
+++ b/tests/unit_tests_features.py
@@ -27,7 +27,7 @@ class FeaturesTests(unittest.TestCase):
         fs = FeatureSelector(rules)
 
         # Feature with specified coordinates, matching rule 0 with hierarchy 0 and the appropriate selector for iv_rule
-        selectors = fs.build_interval_selectors(feat_iv, [(0, 0, iv_rule)])
+        selectors = fs.build_interval_selectors(feat_iv, [(0, 0, iv_rule, Wildcard())])
         match_tuple = (selectors[feat_iv][0],)
         feat = {(feat_id, strand_to_bool(strand), match_tuple)}
 
@@ -398,19 +398,19 @@ class FeaturesTests(unittest.TestCase):
         fs = FeatureSelector(deepcopy(rules_template))
         iv = HTSeq.GenomicInterval('I', 10, 20, '+')
 
-        match_tuples = [('n/a', 'n/a', 'partial'),
-                        ('n/a', 'n/a', 'nested'),
-                        ('n/a', 'n/a', 'exact'),
-                        ('n/a', 'n/a', "5' anchored"),
-                        ('n/a', 'n/a', "3' anchored"),
+        match_tuples = [('n/a', 'n/a', 'partial', 'n/a'),
+                        ('n/a', 'n/a', 'nested', 'n/a'),
+                        ('n/a', 'n/a', 'exact', 'n/a'),
+                        ('n/a', 'n/a', "5' anchored", 'n/a'),
+                        ('n/a', 'n/a', "3' anchored", 'n/a'),
                         # iv_shifted_1                        Shift values:
-                        ('n/a', 'n/a', 'partial, -5, 5'),       # 5': -5    3': 5
-                        ('n/a', 'n/a', 'nested, -5, 5'),        # 5': -5    3': 5
+                        ('n/a', 'n/a', 'partial, -5, 5', 'n/a'),       # 5': -5    3': 5
+                        ('n/a', 'n/a', 'nested, -5, 5', 'n/a'),        # 5': -5    3': 5
                         # iv_shifted_2
-                        ('n/a', 'n/a', 'exact, -10, 10'),       # 5': -10   3': 10
+                        ('n/a', 'n/a', 'exact, -10, 10', 'n/a'),       # 5': -10   3': 10
                         # iv_shifted_3
-                        ('n/a', 'n/a', "5' anchored, -1, -1"),  # 5': -1    3': -1
-                        ('n/a', 'n/a', "3' anchored, -1, -1")]  # 5': -1    3': -1
+                        ('n/a', 'n/a', "5' anchored, -1, -1", 'n/a'),  # 5': -1    3': -1
+                        ('n/a', 'n/a', "3' anchored, -1, -1", 'n/a')]  # 5': -1    3': -1
 
         iv_shifted_1 = HTSeq.GenomicInterval('I', 5, 25, '+')
         iv_shifted_2 = HTSeq.GenomicInterval('I', 0, 30, '+')

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -138,9 +138,9 @@ class SamReaderTests(unittest.TestCase):
         reader._decollapsed_filename = "mock_outfile_name.sam"
 
         expected_writelines = [
-            call('mock_outfile_name.sam', 'ab'),
+            call('mock_outfile_name.sam', 'a'),
             call().__enter__(),
-            call().writelines([alignment.to_string()] * 5),
+            call().write('\n'.join([alignment.to_string()] * 5)),
             call().__exit__(None, None, None)
         ]
 

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -15,6 +15,7 @@ from tiny.rna.counter.hts_parsing import *
 import unit_test_helpers as helpers
 
 resources = "./testdata/counter"
+wc = Wildcard()  # used in many tests as a 'n/a' value
 
 # To run all test suites
 if __name__ == '__main__':
@@ -256,7 +257,7 @@ class ReferenceFeaturesTests(unittest.TestCase):
         steps = list(feats[iv].array[iv.start:iv.end].get_steps(values_only=True))
 
         self.assertEqual((type(feats), type(alias), type(tags)), (HTSeq.GenomicArrayOfSets, dict, defaultdict))
-        self.assertEqual(steps, [{(("Gene:WBGene00023193", 'tag'), False, ((1, 2, IntervalPartialMatch(iv)),))}])
+        self.assertEqual(steps, [{(("Gene:WBGene00023193", 'tag'), False, ((1, 2, IntervalPartialMatch(iv), wc),))}])
         self.assertEqual(alias, {"Gene:WBGene00023193": ('Y74C9A.6',)})
         self.assertDictEqual(tags, {"Gene:WBGene00023193": {('Gene:WBGene00023193', 'tag')}})
 
@@ -280,7 +281,7 @@ class ReferenceFeaturesTests(unittest.TestCase):
         steps = list(feats[iv].array[iv.start:iv.end].get_steps(values_only=True))
 
         self.assertEqual((type(feats), type(alias), type(tags)), (HTSeq.GenomicArrayOfSets, dict, defaultdict))
-        self.assertEqual(steps, [{(("Gene:WBGene00023193", 'tag'), False, ((1, 2, IntervalPartialMatch(iv)),))}])
+        self.assertEqual(steps, [{(("Gene:WBGene00023193", 'tag'), False, ((1, 2, IntervalPartialMatch(iv), wc),))}])
         self.assertDictEqual(alias, {"Gene:WBGene00023193": ('Y74C9A.6',)})
         self.assertDictEqual(tags, {"Gene:WBGene00023193": {('Gene:WBGene00023193', 'tag')}})
 
@@ -365,7 +366,7 @@ class ReferenceFeaturesTests(unittest.TestCase):
 
         expected_matches = [
             set(),
-            {(('Gene:WBGene00023193', ''), False, ((0, 1, ivm), (1, 2, ivm), (2, 3, ivm)))},
+            {(('Gene:WBGene00023193', ''), False, ((0, 1, ivm, wc), (1, 2, ivm, wc), (2, 3, ivm, wc)))},
             set()
         ]
 
@@ -466,10 +467,10 @@ class ReferenceFeaturesTests(unittest.TestCase):
         sib_ivs = [HTSeq.GenomicInterval('I', 99, 110, '-'), HTSeq.GenomicInterval('I', 110, 120, '-'),
                    HTSeq.GenomicInterval('I', 139, 150, '-')]
 
-        rule1_gp =  {f"{iv.start}:{iv.end}": ((0, 2, IntervalPartialMatch(iv)),) for iv in gp_ivs}
-        rule1_p2 =  {f"{iv.start}:{iv.end}": ((0, 2, IntervalPartialMatch(iv)),) for iv in p2_ivs}
-        rule2_sib = {f"{iv.start}:{iv.end}": (1, 3, IntervalPartialMatch(iv))    for iv in sib_ivs}
-        rule3_sib = {f"{iv.start}:{iv.end}": (2, 0, IntervalPartialMatch(iv))    for iv in sib_ivs}
+        rule1_gp =  {f"{iv.start}:{iv.end}": ((0, 2, IntervalPartialMatch(iv), wc),) for iv in gp_ivs}
+        rule1_p2 =  {f"{iv.start}:{iv.end}": ((0, 2, IntervalPartialMatch(iv), wc),) for iv in p2_ivs}
+        rule2_sib = {f"{iv.start}:{iv.end}": (1, 3, IntervalPartialMatch(iv), wc)    for iv in sib_ivs}
+        rule3_sib = {f"{iv.start}:{iv.end}": (2, 0, IntervalPartialMatch(iv), wc)    for iv in sib_ivs}
 
         # For tables that store features in tagged form
         GrandParent, Parent2, Sibling = ('GrandParent',''), ('Parent2',''), ('Sibling','')
@@ -502,7 +503,7 @@ class ReferenceFeaturesTests(unittest.TestCase):
 
         child2_iv =     HTSeq.GenomicInterval('I', 39, 50, '-')
         exp_alias =     {'Child2': ('Child2Name',)}
-        exp_feats =     [set(), {(('Child2', ''), False, ((0, 0, IntervalPartialMatch(child2_iv)),))}, set()]
+        exp_feats =     [set(), {(('Child2', ''), False, ((0, 0, IntervalPartialMatch(child2_iv), wc),))}, set()]
         exp_intervals = {'Child2': [child2_iv]}
         exp_classes =   {'Child2': ('NA',)}
         exp_filtered =  {"GrandParent", "ParentWithGrandparent", "Parent2", "Child1", "Sibling"}
@@ -527,7 +528,7 @@ class ReferenceFeaturesTests(unittest.TestCase):
 
         child1_iv =     HTSeq.GenomicInterval('I', 29, 40, '-')
         exp_alias =     {'Child1': ('SharedName',)}
-        exp_feats =     [set(), {(('Child1', ''), False, ((0, 0, IntervalPartialMatch(child1_iv)),))}, set()]
+        exp_feats =     [set(), {(('Child1', ''), False, ((0, 0, IntervalPartialMatch(child1_iv), wc),))}, set()]
         exp_intervals = {'Child1': [child1_iv]}
         exp_classes =   {'Child1': ('NA',)}
         exp_filtered =  {"GrandParent", "ParentWithGrandparent", "Parent2", "Child2", "Sibling"}
@@ -574,8 +575,8 @@ class ReferenceFeaturesTests(unittest.TestCase):
         iv = IntervalPartialMatch(HTSeq.GenomicInterval('n/a', 3746, 3909))
         expected_feats = [
             set(), {
-                ((feat_id, 'tagged_match'), False, ((0, 1, iv),)),
-                ((feat_id, ''),             False, ((1, 2, iv),))
+                ((feat_id, 'tagged_match'), False, ((0, 1, iv, wc),)),
+                ((feat_id, ''),             False, ((1, 2, iv, wc),))
             },
             set()
         ]
@@ -606,12 +607,12 @@ class ReferenceFeaturesTests(unittest.TestCase):
         Child2_iv = IntervalPartialMatch(HTSeq.GenomicInterval('n/a', 39, 50))
         expected_feats = [
             set(), {
-                (('Parent2', 'shared'), False, ((0, 1, Parent2_iv), (1, 2, Parent2_iv))),
-                (('Parent2', ''),       False, ((2, 3, Parent2_iv),)),
+                (('Parent2', 'shared'), False, ((0, 1, Parent2_iv, wc), (1, 2, Parent2_iv, wc))),
+                (('Parent2', ''),       False, ((2, 3, Parent2_iv, wc),)),
             },
             set(), {
-                (('Parent2', 'shared'), False, ((0, 1, Child2_iv), (1, 2, Child2_iv))),
-                (('Parent2', ''),       False, ((2, 3, Child2_iv),))
+                (('Parent2', 'shared'), False, ((0, 1, Child2_iv, wc), (1, 2, Child2_iv, wc))),
+                (('Parent2', ''),       False, ((2, 3, Child2_iv, wc),))
             },
             set()
         ]
@@ -651,7 +652,7 @@ class ReferenceSequencesTests(unittest.TestCase):
     def test_add_reference_seq_single(self):
         seq_id = "seq"
         seq_len = 10
-        matches = {'': [(0, 0, "partial")]}
+        matches = {'': [(0, 0, "partial", wc)]}
 
         rs = self.ReferenceSeqs_add(seq_id, seq_len, matches)
         actual = self.get_steps(rs, seq_id)
@@ -660,7 +661,7 @@ class ReferenceSequencesTests(unittest.TestCase):
         # and the overlap selector should have the same interval.
         # For these selectors, same interval on both strands.
         iv = HTSeq.GenomicInterval(seq_id, 0, seq_len)
-        match_tuple = ((0, 0, IntervalPartialMatch(iv)),)
+        match_tuple = ((0, 0, IntervalPartialMatch(iv), wc),)
 
         expected = {
             (0, 10): {
@@ -677,7 +678,7 @@ class ReferenceSequencesTests(unittest.TestCase):
     def test_add_reference_seq_shared_classifier(self):
         seq_id = "seq"
         seq_len = 10
-        matches = {'shared': [(0, 0, "partial"), (1, 1, "nested")]}
+        matches = {'shared': [(0, 0, "partial", wc), (1, 1, "nested", wc)]}
 
         rs = self.ReferenceSeqs_add(seq_id, seq_len, matches)
         actual = self.get_steps(rs, seq_id)
@@ -686,7 +687,7 @@ class ReferenceSequencesTests(unittest.TestCase):
         # and the overlap selector should have the same interval.
         # For these selectors, same interval on both strands.
         iv = HTSeq.GenomicInterval(seq_id, 0, seq_len)
-        match_tuples = (0, 0, IntervalPartialMatch(iv)), (1, 1, IntervalNestedMatch(iv))
+        match_tuples = (0, 0, IntervalPartialMatch(iv), wc), (1, 1, IntervalNestedMatch(iv), wc)
 
         expected = {
             (0, 10): {
@@ -704,7 +705,7 @@ class ReferenceSequencesTests(unittest.TestCase):
     def test_add_reference_seq_shared_iv(self):
         seq_id = "seq"
         seq_len = 10
-        matches = {'exact': [(0, 0, "exact, 2, -2")], 'nested': [(1, 1, "nested, 2, -2")]}
+        matches = {'exact': [(0, 0, "exact, 2, -2", wc)], 'nested': [(1, 1, "nested, 2, -2", wc)]}
 
         rs = self.ReferenceSeqs_add(seq_id, seq_len, matches)
         actual = self.get_steps(rs, seq_id)
@@ -713,8 +714,8 @@ class ReferenceSequencesTests(unittest.TestCase):
         # and the overlap selector should have the same interval.
         # For these selectors, same interval on both strands.
         iv = HTSeq.GenomicInterval(seq_id, 2, seq_len - 2)
-        match_exact =  ((0, 0, IntervalExactMatch(iv)),)
-        match_nested = ((1, 1, IntervalNestedMatch(iv)),)
+        match_exact =  ((0, 0, IntervalExactMatch(iv), wc),)
+        match_nested = ((1, 1, IntervalNestedMatch(iv), wc),)
 
         expected = {
             (0, 2): set(),
@@ -737,8 +738,8 @@ class ReferenceSequencesTests(unittest.TestCase):
         seq_id = "seq"
         seq_len = 10
         matches = {
-            "class1": [(0, 0, "nested, 1, -1"), (0, 0, "exact, 5, 0")],
-            "class2": [(0, 0, "5' anchored, 5, 0")]
+            "class1": [(0, 0, "nested, 1, -1", wc), (0, 0, "exact, 5, 0", wc)],
+            "class2": [(0, 0, "5' anchored, 5, 0", wc)]
         }
 
         rs = self.ReferenceSeqs_add(seq_id, seq_len, matches)
@@ -746,19 +747,19 @@ class ReferenceSequencesTests(unittest.TestCase):
 
         # Since nested shift is symmetric, iv is same on both strands
         iv_n = HTSeq.GenomicInterval(seq_id, 1, seq_len-1)
-        match_nested = ((0, 0, IntervalNestedMatch(iv_n)),)
+        match_nested = ((0, 0, IntervalNestedMatch(iv_n), wc),)
 
         # Since exact and anchored shift is asymmetric and by the same
         # amount, iv differs per strand but is shared by both selectors.
         # If they both had the same classifier then these match tuples
         # would share the same record tuple on both strands
         iv_e5_s = HTSeq.GenomicInterval(seq_id, 5, seq_len, '+')
-        match_exact_sense = ((0, 0, IntervalExactMatch(iv_e5_s)),)
-        match_5anch_sense = ((0, 0, Interval5pMatch(iv_e5_s)),)
+        match_exact_sense = ((0, 0, IntervalExactMatch(iv_e5_s), wc),)
+        match_5anch_sense = ((0, 0, Interval5pMatch(iv_e5_s), wc),)
 
         iv_e5_a = HTSeq.GenomicInterval(seq_id, 0, seq_len-5, '-')
-        match_exact_antis = ((0, 0, IntervalExactMatch(iv_e5_a)),)
-        match_5anch_antis = ((0, 0, Interval5pMatch(iv_e5_a)),)
+        match_exact_antis = ((0, 0, IntervalExactMatch(iv_e5_a), wc),)
+        match_5anch_antis = ((0, 0, Interval5pMatch(iv_e5_a), wc),)
 
         expected = {
             (0, 1): {

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -45,8 +45,8 @@ class SamReaderTests(unittest.TestCase):
         self.assertEqual(sam_record['Start'], 15064569)
         self.assertEqual(sam_record['End'], 15064590)
         self.assertEqual(sam_record['Strand'], False)
-        self.assertEqual(sam_record['Name'], b"0_count=5")
-        self.assertEqual(sam_record['Seq'], b"CAAGACAGAGCTTCACCGTTC")
+        self.assertEqual(sam_record['Name'], "0_count=5")
+        self.assertEqual(sam_record['Seq'], "CAAGACAGAGCTTCACCGTTC")
         self.assertEqual(sam_record['Length'], 21)
         self.assertEqual(sam_record['nt5end'], 'G')
 
@@ -69,13 +69,13 @@ class SamReaderTests(unittest.TestCase):
                 self.assertEqual(our['Chrom'], their.iv.chrom)
                 self.assertEqual(our['Start'], their.iv.start)
                 self.assertEqual(our['End'], their.iv.end)
-                self.assertEqual(our['Name'].decode(), their.read.name)
+                self.assertEqual(our['Name'], their.read.name)
                 self.assertEqual(our['nt5end'], chr(their.read.seq[0]))  # See note above
                 self.assertEqual(our['Strand'], helpers.strand_to_bool(their.iv.strand))
                 if our['Strand'] is False:  # See note above
-                    self.assertEqual(our['Seq'][::-1].translate(helpers.complement), their.read.seq)
+                    self.assertEqual(our['Seq'][::-1].translate(helpers.complement), their.read.seq.decode())
                 else:
-                    self.assertEqual(our['Seq'], their.read.seq)
+                    self.assertEqual(our['Seq'], their.read.seq.decode())
 
     """Does SAM_reader._get_decollapsed_filename() create an appropriate filename?"""
 

--- a/tests/unit_tests_matching.py
+++ b/tests/unit_tests_matching.py
@@ -20,15 +20,15 @@ class MyTestCase(unittest.TestCase):
         iv = HTSeq.GenomicInterval('I', 0, 10, '+')
 
         # Match tuples formed during GFF parsing
-        match_tuples = [('n/a', 'n/a', 'partial'),
-                        ('n/a', 'n/a', 'nested'),
-                        ('n/a', 'n/a', 'exact'),
-                        ('n/a', 'n/a', 'anchored'),
-                        ('n/a', 'n/a', "5' anchored"),
-                        ('n/a', 'n/a', "3' anchored"),
-                        ('n/a', 'n/a', "5'anchored"),   # spaces should be optional
-                        ('n/a', 'n/a', "3'anchored")]
-        match_tuples += [('n/a', 'n/a', kwd) for kwd in Wildcard.kwds]
+        match_tuples = [('n/a', 'n/a', 'partial', Wildcard()),
+                        ('n/a', 'n/a', 'nested', Wildcard()),
+                        ('n/a', 'n/a', 'exact', Wildcard()),
+                        ('n/a', 'n/a', 'anchored', Wildcard()),
+                        ('n/a', 'n/a', "5' anchored", Wildcard()),
+                        ('n/a', 'n/a', "3' anchored", Wildcard()),
+                        ('n/a', 'n/a', "5'anchored", Wildcard()),   # spaces should be optional
+                        ('n/a', 'n/a', "3'anchored", Wildcard())]
+        match_tuples += [('n/a', 'n/a', kwd, Wildcard()) for kwd in Wildcard.kwds]
 
         result = fs.build_interval_selectors(iv, match_tuples)
 

--- a/tests/unit_tests_validation.py
+++ b/tests/unit_tests_validation.py
@@ -6,7 +6,7 @@ import io
 from glob import glob
 from unittest.mock import patch, mock_open
 
-from rna.counter.validation import GFFValidator, ReportFormatter, SamSqValidator
+from tiny.rna.counter.validation import GFFValidator, ReportFormatter, SamSqValidator
 
 
 class GFFValidatorTest(unittest.TestCase):
@@ -314,6 +314,23 @@ class SamSqValidatorTest(unittest.TestCase):
                 {'SN': chrom[0]} if not chrom[1] else
                 {'LN': chrom[1]}
                 for chrom in chroms]
+
+    """Does read_sq_headers() return the expected data?"""
+
+    def test_read_sq_headers(self):
+        sam_file = 'testdata/counter/validation/sam/sq_headers.sam'
+        expected = {
+            sam_file: [
+                {'SN': 'I',  'LN': 123},
+                {'SN': 'II', 'LN': 456},
+                {'SN': 'III'}
+            ],
+        }
+
+        validator = SamSqValidator([sam_file])
+        validator.read_sq_headers()
+
+        self.assertDictEqual(validator.sq_headers, expected)
 
     """Does SamSqValidator correctly identify missing @SQ headers?"""
 

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -771,6 +771,7 @@ class CSVReader(csv.DictReader):
            "5' End Nucleotide": "nt5end",
            "Length":            "Length",
            "Overlap":           "Overlap",
+           "Mismatches":        "Mismatch"
         }),
         "Samples Sheet": OrderedDict({
             "FASTQ/SAM Files":   "File",
@@ -858,6 +859,10 @@ class CSVReader(csv.DictReader):
             self.fieldnames = tuple(doc_ref_lowercase[key] for key in header_lowercase.values())
 
     def check_backward_compatibility(self, header_vals):
+        """Catch column differences from old versions so a helpful error can be provided"""
+
+        assert all(val.isupper() for val in header_vals), "Lowercase headers expected."
+
         compat_errors = []
         if self.doctype == "Features Sheet":
             if len(header_vals & {'alias by...', 'feature source'}):
@@ -886,6 +891,14 @@ class CSVReader(csv.DictReader):
                     "class is no longer determined by the Class= attribute. Please review the Stage 1",
                     'section in tiny-count\'s documentation, then rename the "Tag" column to',
                     '"Classify as..." to avoid this error.'
+                ]))
+
+            if 'mismatches' not in header_vals:
+                compat_errors.append('\n'.join([
+                    "It looks like you're using a Features Sheet from an earlier version of",
+                    'tinyRNA. An additional column, "Mismatches", is now expected. Please review'
+                    "the Stage 2 section in tiny-count's documentation for more info, then add"
+                    "the new column to your Features Sheet to avoid this error."
                 ]))
 
         if compat_errors: raise ValueError('\n\n'.join(compat_errors))

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -861,11 +861,11 @@ class CSVReader(csv.DictReader):
     def check_backward_compatibility(self, header_vals):
         """Catch column differences from old versions so a helpful error can be provided"""
 
-        assert all(val.isupper() for val in header_vals), "Lowercase headers expected."
+        header_vals_lc = {val.lower() for val in header_vals}
 
         compat_errors = []
         if self.doctype == "Features Sheet":
-            if len(header_vals & {'alias by...', 'feature source'}):
+            if len(header_vals_lc & {'alias by...', 'feature source'}):
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from an earlier version of",
                     "tinyRNA. Feature aliases and GFF files are now defined in the Paths File.",
@@ -874,7 +874,7 @@ class CSVReader(csv.DictReader):
                     "your Features Sheet to avoid this error."
                 ]))
 
-            if len(header_vals & {'source filter', 'type filter'}) != 2:
+            if len(header_vals_lc & {'source filter', 'type filter'}) != 2:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from an earlier version of",
                     "tinyRNA. Source and type filters are now defined in the Features Sheet.",
@@ -883,7 +883,7 @@ class CSVReader(csv.DictReader):
                     '"Source Filter" and "Type Filter" to your Features Sheet to avoid this error.'
                 ]))
 
-            if 'tag' in header_vals:
+            if 'tag' in header_vals_lc:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from a version of tinyRNA",
                     'that offered "tagged counting". The "Tag" header has been repurposed as a feature',
@@ -893,7 +893,7 @@ class CSVReader(csv.DictReader):
                     '"Classify as..." to avoid this error.'
                 ]))
 
-            if 'mismatches' not in header_vals:
+            if 'mismatches' not in header_vals_lc:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from an earlier version of",
                     'tinyRNA. An additional column, "Mismatches", is now expected. Please review'

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -2,17 +2,19 @@ import HTSeq
 import sys
 
 from collections import defaultdict
-from typing import List, Tuple, Set, Dict, Mapping
+from typing import List, Tuple, Set, Dict, Mapping, Union
 
-from tiny.rna.counter.hts_parsing import SAM_reader, ReferenceFeatures, ReferenceSeqs
+from tiny.rna.counter.hts_parsing import ReferenceFeatures, ReferenceSeqs, SAM_reader
 from .statistics import LibraryStats
 from .matching import *
 from ..util import append_to_exception
 
 # Type aliases for human readability
-match_tuple = Tuple[int, int, IntervalSelector]             # (rank, rule, IntervalSelector)
-unbuilt_match_tuple = Tuple[int, int, str]                  # (rank, rule, interval selector keyword)
-feature_record_tuple = Tuple[str, str, Tuple[match_tuple]]  # (feature ID, strand, match tuple)
+interval_selector = Union[IntervalSelector, Wildcard]
+mismatch_selector = Union[NumericalMatch, Wildcard]
+match_tuple = Tuple[int, int, interval_selector, mismatch_selector]  # (rank, rule, IntervalSelector, NumericalMatch)
+unbuilt_match_tuple = Tuple[int, int, str, mismatch_selector]        # (rank, rule, overlap, NumericalMatch)
+feature_record_tuple = Tuple[str, str, Tuple[match_tuple]]           # (feature ID, strand, match tuple)
 
 
 class Features(metaclass=Singleton):
@@ -89,14 +91,12 @@ class FeatureSelector:
 
     The first round of selection was performed during GFF parsing.
 
-    The second round is performed against the hierarchy values and
-    IntervalSelectors in each candidate's match-tuples.
+    The second round is performed against the overlap and mismatch selectors
+    which are stored in each candidate's match tuples. These matches are then
+    sorted by hierarchy value.
 
     If more than one candidate remains, a final round of selection is performed
-    against sequence attributes: strand, 5' end nucleotide, and length. Rules for
-    5' end nucleotides support lists (e.g. C,G,U) and wildcards (e.g. "all").
-    Rules for length support lists, wildcards, and ranges (e.g. 20-27) which
-    may be intermixed in the same rule.
+    against sequence attributes: strand, 5' end nucleotide, and length.
     """
 
     rules_table: List[dict]
@@ -122,7 +122,7 @@ class FeatureSelector:
                 ( featureID, strand, ( match_tuple, ... ) )
 
             Each match_tuple represents a rule which matched the feature on identity:
-                ( rule, rank, IntervalSelector )
+                ( rule, rank, IntervalSelector, NumericalSelector )
 
         Args:
             candidates: a list of tuples, each representing features associated with

--- a/tiny/rna/counter/features.py
+++ b/tiny/rna/counter/features.py
@@ -136,8 +136,8 @@ class FeatureSelector:
         # Stage 2
         hits = [(rank, rule, feat, strand)
                 for feat, strand, matches in candidates
-                for rule, rank, iv_match in matches
-                if alignment in iv_match]
+                for rule, rank, iv_match, nm_match in matches
+                if alignment in iv_match and alignment['NM'] in nm_match]
 
         if not hits: return {}
         hits.sort(key=lambda x: x[0])
@@ -178,6 +178,7 @@ class FeatureSelector:
             "Strand": StrandMatch,
             "nt5end": NtMatch,
             "Length": NumericalMatch,
+            "Mismatch": NumericalMatch,
             "Identity": lambda x:x
         }
 
@@ -261,7 +262,7 @@ class FeatureSelector:
                     continue
 
             # Replace the match tuple's definition with selector
-            built_match_tuple = (match[0], match[1], selector_obj)
+            built_match_tuple = (match[0], match[1], selector_obj, match[3])
             matches_by_interval[match_iv].append(built_match_tuple)
 
         return matches_by_interval

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -85,6 +85,9 @@ class SAM_reader:
         header = reader.header
         first_aln = next(reader.head(1))
 
+        if first_aln.query_sequence is None:
+            raise ValueError("SAM alignments must include the read sequence.")
+
         self._header = header
         self._header_dict = header.to_dict()  # performs validation
         self._determine_collapser_type(first_aln.query_name)
@@ -459,9 +462,9 @@ class ReferenceFeatures(ReferenceBase):
     Children of the root ancestor are otherwise not stored in the reference tables.
 
     Match-tuples are created for each Features Sheet rule which matches a feature's attributes.
-    They are structured as (rank, rule, overlap). "Rank" is the hierarchy value of the matching
-    rule, "rule" is the index of that rule in FeatureSelector's rules table, and "overlap" is the
-    IntervalSelector per the rule's overlap requirements.
+    They are structured as (rank, rule, overlap, mismatches). "Rank" is the hierarchy value of
+    the matching rule, "rule" is the index of that rule in FeatureSelector's rules table, and
+    "overlap" is the IntervalSelector per the rule's overlap requirements.
 
     Source and type filters allow the user to define acceptable values for columns 2 and 3 of the
     GFF, respectively. These filters are inclusive (only rows with matching values are parsed),

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -561,10 +561,10 @@ class ReferenceFeatures(ReferenceBase):
                     if self.column_filter_match(row, rule):
                         # Unclassified matches are pooled under '' empty string
                         identity_matches[rule['Class']].add(
-                            (index, rule['Hierarchy'], rule['Overlap'])
+                            (index, rule['Hierarchy'], rule['Overlap'], rule['Mismatch'])
                         )
 
-        # -> identity_matches: {classifier: {(rule, rank, overlap), ...}, ...}
+        # -> identity_matches: {classifier: {(rule, rank, overlap, mismatch), ...}, ...}
         return identity_matches
 
     def add_feature(self, feature_id: str, row, matches: defaultdict) -> str:

--- a/tiny/rna/counter/hts_parsing.py
+++ b/tiny/rna/counter/hts_parsing.py
@@ -151,8 +151,8 @@ class SAM_reader:
             aln_out.extend([aln.to_string()] * seq_count)
             prev_name = name
 
-        with open(self._get_decollapsed_filename(), 'ab') as sam_o:
-            sam_o.writelines(aln_out)
+        with open(self._get_decollapsed_filename(), 'a') as sam_o:
+            sam_o.write('\n'.join(aln_out))
             self._decollapsed_reads.clear()
 
 
@@ -773,7 +773,7 @@ class ReferenceSeqs(ReferenceBase):
         matches_by_classifier = defaultdict(list)
 
         for idx, rule in enumerate(self.selector.rules_table):
-            match_tuple = (idx, rule['Hierarchy'], rule['Overlap'])
+            match_tuple = (idx, rule['Hierarchy'], rule['Overlap'], rule['Mismatch'])
             matches_by_classifier[rule['Class']].append(match_tuple)
 
         return matches_by_classifier

--- a/tiny/rna/counter/parsing/__init__.py
+++ b/tiny/rna/counter/parsing/__init__.py
@@ -1,1 +1,1 @@
-from .sam_reader import AlignmentIter
+from .alignments import AlignmentIter

--- a/tiny/rna/counter/parsing/__init__.py
+++ b/tiny/rna/counter/parsing/__init__.py
@@ -1,0 +1,1 @@
+from .sam_reader import AlignmentIter

--- a/tiny/rna/counter/parsing/alignments.pyx
+++ b/tiny/rna/counter/parsing/alignments.pyx
@@ -35,13 +35,13 @@ cdef class AlignmentIter:
 
     cdef dict _next_alignment(self):
         cdef:
-            AlignedSegment aln = next(self.reader)                  # Equivalent API calls:
+            AlignedSegment aln = next(self.reader)                  # Equivalent Python API calls:
             int flag = aln._delegate.core.flag                          # aln.flag
-            str seq = aln.query_sequence                                # aln.query_sequence
+            str seq = aln.query_sequence
             int start = aln._delegate.core.pos                          # aln.reference_start
             int length = aln._delegate.core.l_qseq                      # aln.query_length
             bint strand = (flag & BAM_FREVERSE) == 0                    # aln.is_forward
-            str nt5 = self._get_nt5(seq, strand)
+            str nt5 = AlignmentIter._get_nt5(seq, strand)
             str name = pysam_bam_get_qname(aln._delegate).decode()      # aln.query_name
 
         if (flag & BAM_FUNMAP) != 0:                                    # aln.is_unmapped
@@ -78,7 +78,8 @@ cdef class AlignmentIter:
         # Calculate mismatches using the CIGAR string's I, D, and X operations
         return sum(op_len for op, op_len in aln.cigartuples if op in cigar_mismatch)
 
-    cdef str _get_nt5(self, str seq, bint strand):
+    @staticmethod
+    cdef str _get_nt5(str seq, bint strand):
         cdef str nt
 
         if strand:

--- a/tiny/rna/counter/parsing/alignments.pyx
+++ b/tiny/rna/counter/parsing/alignments.pyx
@@ -6,6 +6,8 @@ from pysam.libcalignmentfile cimport AlignmentFile, AlignedSegment
 from pysam.libcalignedsegment cimport pysam_bam_get_qname
 from pysam.libchtslib cimport bam_aux_get, bam_aux2i, BAM_FUNMAP, BAM_FREVERSE
 
+from typing import Callable
+
 cdef tuple cigar_mismatch = (1, 2, 8)
 
 cdef class AlignmentIter:
@@ -17,7 +19,7 @@ cdef class AlignmentIter:
     cdef bint decollapse
     cdef bint has_nm
 
-    def __init__(self, pysam_reader, has_nm, dc_callback, dc_queue):
+    def __init__(self, pysam_reader: AlignmentFile, has_nm: bool, dc_callback: Callable, dc_queue: list):
         self.reader = pysam_reader
         self.references = pysam_reader.header.references
         self.decollapse = dc_callback is not None

--- a/tiny/rna/counter/parsing/alignments.pyx
+++ b/tiny/rna/counter/parsing/alignments.pyx
@@ -1,0 +1,95 @@
+# cython: language_level = 3
+# cython: profile=False
+
+cimport cython
+from pysam.libcalignmentfile cimport AlignmentFile, AlignedSegment
+from pysam.libcalignedsegment cimport pysam_bam_get_qname
+from pysam.libchtslib cimport bam_aux_get, bam_aux2i, BAM_FUNMAP, BAM_FREVERSE
+
+cdef tuple cigar_mismatch = (1, 2, 8)
+
+cdef class AlignmentIter:
+
+    cdef AlignmentFile reader
+    cdef tuple references
+    cdef object dc_callback
+    cdef list dc_queue
+    cdef bint decollapse
+    cdef bint has_nm
+
+    def __init__(self, pysam_reader, has_nm, dc_callback, dc_queue):
+        self.reader = pysam_reader
+        self.references = pysam_reader.header.references
+        self.decollapse = dc_callback is not None
+        self.dc_callback = dc_callback
+        self.dc_queue = dc_queue
+        self.has_nm = has_nm
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self._next_alignment()
+
+    cdef dict _next_alignment(self):
+        cdef:
+            AlignedSegment aln = next(self.reader)                  # Equivalent API calls:
+            int flag = aln._delegate.core.flag                          # aln.flag
+            str seq = aln.query_sequence                                # aln.query_sequence
+            int start = aln._delegate.core.pos                          # aln.reference_start
+            int length = aln._delegate.core.l_qseq                      # aln.query_length
+            bint strand = (flag & BAM_FREVERSE) == 0                    # aln.is_forward
+            str nt5 = self._get_nt5(seq, strand)
+            str name = pysam_bam_get_qname(aln._delegate).decode()      # aln.query_name
+
+        if (flag & BAM_FUNMAP) != 0:                                    # aln.is_unmapped
+            return self._next_alignment()
+
+        if self.decollapse:
+            self._append_to_dc_queue(aln)
+
+        if self.has_nm:
+            mismatches = AlignmentIter._get_mismatches_from_nm(aln)     # aln.get_tag("NM")
+        else:
+            mismatches = AlignmentIter._get_mismatches_from_cigar(aln)
+
+        return {
+            "Name": name,
+            "Length": length,
+            "Seq": seq,
+            "nt5end": nt5,
+            "Chrom": self.references[aln._delegate.core.tid],           # aln.reference_name
+            "Start": start,
+            "End": start + length,
+            "Strand": strand,
+            "NM": mismatches
+        }
+
+    @staticmethod
+    cdef _get_mismatches_from_nm(AlignedSegment aln):
+        nm = bam_aux_get(aln._delegate, b"NM")
+        if nm == NULL: return 0  # Assume missing tag means NM:i:0
+        return bam_aux2i(nm)
+
+    @staticmethod
+    cdef _get_mismatches_from_cigar(AlignedSegment aln):
+        # Calculate mismatches using the CIGAR string's I, D, and X operations
+        return sum(op_len for op, op_len in aln.cigartuples if op in cigar_mismatch)
+
+    cdef str _get_nt5(self, str seq, bint strand):
+        cdef str nt
+
+        if strand:
+            return seq[0]
+        else:
+            nt = seq[-1]
+            if nt == "A": return "T"
+            elif nt == "T": return "A"
+            elif nt == "G": return "C"
+            elif nt == "C": return "G"
+            else: return nt
+
+    cdef _append_to_dc_queue(self, AlignedSegment aln):
+        self.dc_queue.append(aln)
+        if len(self.dc_queue) > 100_000:
+            self.dc_callback()

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -342,8 +342,5 @@ class SamSqValidator:
 
     def read_sq_headers(self):
         for file in self.sam_files:
-            sr = SAM_reader()
-            pr = pysam.AlignmentFile(file, check_sq=True)
-            sr._gather_metadata(pr)
-
-            self.sq_headers[file] = sr._header_dict.get('SQ', [])
+            pr = pysam.AlignmentFile(file, check_sq=False)
+            self.sq_headers[file] = pr.header.to_dict().get('SQ', [])

--- a/tiny/rna/counter/validation.py
+++ b/tiny/rna/counter/validation.py
@@ -1,5 +1,6 @@
 import functools
 import subprocess
+import pysam
 import sys
 import os
 
@@ -341,8 +342,8 @@ class SamSqValidator:
 
     def read_sq_headers(self):
         for file in self.sam_files:
-            with open(file, 'rb') as f:
-                reader = SAM_reader()
-                reader._read_to_first_aln(f)
+            sr = SAM_reader()
+            pr = pysam.AlignmentFile(file, check_sq=True)
+            sr._gather_metadata(pr)
 
-            self.sq_headers[file] = reader._header_dict.get('@SQ', [])
+            self.sq_headers[file] = sr._header_dict.get('SQ', [])

--- a/tiny/templates/features.csv
+++ b/tiny/templates/features.csv
@@ -1,2 +1,2 @@
-Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Strand,5' End Nucleotide,Length,Overlap
+Select for...,with value...,Classify as...,Source Filter,Type Filter,Hierarchy,Overlap,Mismatches,Strand,5' End Nucleotide,Length
 ,,,,,,,,,


### PR DESCRIPTION
This PR introduces a new selector for tiny-count: Mismatches. It is used for placing constraints on the edit distance between an alignment and the reference, and it is evaluated in Stage 2 after the Overlap selector. Users can specify ranges, lists, wildcards, and single values in this column.

Edit distance is determined from the NM tag. If the first alignment in a SAM file is missing the tag, then the edit distance for all subsequent alignments is calculated from the CIGAR string's I, D, and X operations. If the first alignment has an NM tag and a subsequent alignment does not, then the subsequent alignment's edit distance assumes a default value of zero.

The former function for producing alignment dictionaries, SAM_reader._parse_alignments(), has been converted to a standalone Cython class which utilizes pysam's Cython API. As a result, runtimes appear to be negligibly affected (~4-5% slower) rather than the 20-30% reduction measured while using pysam's Python API. This dedicated class is also responsible for accumulating alignments for decollapsed outputs, but delegates all other decollapsing responsibility to the Python-space SAM_reader class. I've made an effort to minimize the Cython surface area due to its complications with debugging.

Additionally:
- The first sequence in each alignment file is checked to make sure that it contains the read sequence (error otherwise)
- If the user elects to have decollapsed outputs produced, alignments are accumulated as pysam's AlignedSegmet objects rather than alignment dictionaries because they have a significantly smaller memory footprint
- The column order of the Features Sheet (specifically the Overlap column) has been updated to match the order shown in the selection diagram

Closes #296 