### PR TITLE
tiny-count: bugfixes and improvements in diagnostic outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,14 +239,23 @@ Two tables are produced:
 
 #### Diagnostics
 
-Diagnostic information will include intermediate alignment files for each library and an additional stats table with information about counts that were not assigned to a feature. Intermediate alignment files include the following information about each alignment, regardless of feature assignment status:
+Diagnostic information can optionally be produced. If enabled, tiny-count will provide a table for each library which contains feature assignment info on a per-alignment basis, along with a single table that summarizes unassigned counts.
 
-- The alignment's SEQ field, reverse complemented for the - strand
-- The sequence's count normalized by its multi-alignment locus count
-- Feature IDs of all features assigned to the alignment
-- Strand, start, and end position
+The alignment tables (**... alignment_table.csv**) include the following information per-alignment:
 
-The unassigned counts table includes the following, with a column per library:
+| Column            | Description                                                                                                                                                        |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Sequence          | The read sequence, reverse complemented if antisense                                                                                                               |
+| Normalized Count  | The reads available for assignment (the sequence's original read count normalized by genomic hits)                                                                 |
+| Chrom             | The alignment's RNAME field                                                                                                                                        |
+| Strand            | The alignment's strand                                                                                                                                             |
+| Start             | The alignment's start coordinate                                                                                                                                   |
+| End               | The alignment's end coordinate                                                                                                                                     |
+| Candidates        | The number of features overlapping the alignment by at last one nucleotide                                                                                         |
+| Assigned Features | Feature IDs of all features assigned to the alignment. `NONE` if no features were assigned. If the assigning rule has a classifier, it is included in parentheses. |
+
+
+The unassigned counts table (**assignment_diags.csv**) includes the following, with a column per library:
 
 | Stat                              | Description                                                                                                                                   |
 |-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|

--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -235,7 +235,7 @@ counter_decollapse: False
 ##-- Select the StepVector implementation that is used. Options: HTSeq or Cython --##
 counter_stepvector: 'Cython'
 
-##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+##-- If True: produce alignment tables and assignment diagnostics for uncounted reads --##
 counter_diags: False
 
 

--- a/tests/testdata/config_files/run_config_template.yml
+++ b/tests/testdata/config_files/run_config_template.yml
@@ -235,7 +235,7 @@ counter_decollapse: False
 ##-- Select the StepVector implementation that is used. Options: HTSeq or Cython --##
 counter_stepvector: 'Cython'
 
-##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+##-- If True: produce alignment tables and assignment diagnostics for uncounted reads --##
 counter_diags: False
 
 

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -125,15 +125,15 @@ outputs:
     outputBinding:
       glob: "*_decollapsed.sam"
 
-  intermed_out_files:
+  alignment_tables:
     type: File[]?
     outputBinding:
-      glob: "*_aln_table.txt"
+      glob: "*_alignment_table.csv"
 
-  alignment_diags:
+  assignment_diags:
     type: File?
     outputBinding:
-      glob: $(inputs.out_prefix)_alignment_diags.csv
+      glob: $(inputs.out_prefix)_assignment_diags.csv
 
   selection_diags:
     type: File?

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -224,8 +224,8 @@ steps:
       fastp_logs: preprocessing/json_report_file
       collapsed_fa: preprocessing/uniq_seqs
     out: [ feature_counts, rule_counts, norm_counts, mapped_nt_len_dist, assigned_nt_len_dist,
-           alignment_stats, summary_stats, decollapsed_sams, intermed_out_files,
-           alignment_diags, selection_diags ]
+           alignment_stats, summary_stats, decollapsed_sams, alignment_tables,
+           assignment_diags, selection_diags ]
 
   tiny-deseq:
     run: ../tools/tiny-deseq.cwl
@@ -321,7 +321,7 @@ steps:
         source: [ tiny-count/feature_counts, tiny-count/rule_counts, tiny-count/norm_counts,
                   tiny-count/mapped_nt_len_dist, tiny-count/assigned_nt_len_dist,
                   tiny-count/alignment_stats, tiny-count/summary_stats, tiny-count/decollapsed_sams,
-                  tiny-count/alignment_diags, tiny-count/selection_diags, tiny-count/intermed_out_files,
+                  tiny-count/assignment_diags, tiny-count/selection_diags, tiny-count/alignment_tables,
                   features_csv ]
       dir_name: dir_name_tiny-count
     out: [ subdir ]

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -235,7 +235,7 @@ counter_decollapse: False
 ##-- Select the StepVector implementation that is used. Options: HTSeq or Cython --##
 counter_stepvector: 'Cython'
 
-##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+##-- If True: produce alignment tables and assignment diagnostics for uncounted reads --##
 counter_diags: False
 
 


### PR DESCRIPTION
- Classifier-related bugs have been fixed
- Alignment tables are now produced as CSVs rather than TSVs
- Alignment tables now include the alignment's chromosome as well as the number of feature candidates that were available for selection at the beginning of Stage 2. Strand is also represented as +/-/. rather than True/False/None.
- Output files have been renamed: 
    - ...aln_table.txt ---> ...alignment_table.csv
    - alignment_diags.csv ---> assignment_diags.csv

Please close PR #298 first
Closes #299 