### PR TITLE
tiny-count: option for normalization by genomic hits, improvements in stats collection precision 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ And this feature matched a rule in your Features Sheet defining _Classify as..._
 | 406904     | miRNA      | mir-1, hsa-miR-1 | 1234         | 999          | ... |
 
 #### Normalized Counts
-If your Samples Sheet has settings for Normalization, an additional copy of the Feature Counts table is produced with the specified per-library normalizations applied.
+If your Samples Sheet has settings for Normalization, an additional copy of the Feature Counts table is produced with the specified per-library normalizations applied. Note that these normalizations are [unrelated to normalization by genomic/feature hits](doc/Configuration.md#applying-custom-normalization).
 
 #### Counts by Rule
 This table shows the counts assigned by each rule on a per-library basis. It is indexed by the rule's corresponding row number in the Features Sheet, where the first non-header row is considered row 0. For convenience a Rule String column is added which contains a human friendly concatenation of each rule. Finally, a Mapped Reads row is added which represents each library's total read counts which were available for assignment prior to counting/selection.
@@ -228,6 +228,13 @@ A single table of summary statistics includes columns for each library and the f
 | <nobr>Mapped Sequences</nobr> | Total genome-mapping sequences passing quality filtering                                                                                   |
 | Mapped Reads                  | Total genome-mapping reads passing quality filtering prior to counting/selection                                                           |                                                          |
 | Assigned Reads                | Total genome-mapping reads passing quality filtering that were assigned to at least one feature due to a rule match in your Features Sheet |
+
+When normalization by feature and/or genomic hits is disabled, the following stats are reported instead of `Mapped Reads`:
+
+| Stat                        | Description                                                                      |
+|-----------------------------|----------------------------------------------------------------------------------|
+| Normalized Mapped Reads     | The true mapped read count                                                       |
+| Non-normalized Mapped Reads | The sum of assigned and unassigned reads according to the normalization settings |
 
 #### 5'nt vs. Length Matrix
 

--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -226,7 +226,7 @@ shared_memory: False
 counter_all_features: False
 
 ##-- If True: counts are normalized by genomic hits (number of multi-alignments) --##
-counter_normalize_by_genomic_hits: False
+counter_normalize_by_genomic_hits: True
 
 ##-- If True: counts are normalized by feature hits (selected feature count per-locus) --##
 counter_normalize_by_feature_hits: True
@@ -328,7 +328,7 @@ dir_name_logs: logs
 #
 ###########################################################################################
 
-version: 1.3.0
+version: 1.4.0
 
 ######--------------------------- DERIVED FROM PATHS FILE ---------------------------######
 #

--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -225,9 +225,11 @@ shared_memory: False
 ##-- If True: show all parsed features in the counts csv, regardless of count/identity --##
 counter_all_features: False
 
-##-- If True: counts will be normalized by genomic hits AND selected feature count --##
-##-- If False: counts will only be normalized by genomic hits --##
-counter_normalize_by_hits: True
+##-- If True: counts are normalized by genomic hits (number of multi-alignments) --##
+counter_normalize_by_genomic_hits: False
+
+##-- If True: counts are normalized by feature hits (selected feature count per-locus) --##
+counter_normalize_by_feature_hits: True
 
 ##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
 counter_decollapse: False

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -136,7 +136,7 @@ Supported values are:
 - **Any number**: the corresponding library's counts are divided by this number (useful for spike-in normalization)
 - **RPM or rpm**: the corresponding library's counts are divided by (its mapped read count / 1,000,000)
 
->**NOTE**: These normalizations operate independently of tiny-count's --normalize-by-hits commandline option. The former is concerned with per-library normalization, whereas the latter is concerned with normalization by selected feature count at each locus ([more info](tiny-count.md#count-normalization)). The commandline option does not enable or disable the normalizations detailed above.
+>**NOTE**: These normalizations operate independently of tiny-count's --normalize-by-genomic/feature-hits commandline options. The former is concerned with per-library normalization, whereas the latter is concerned with normalization by each sequence's alignment count and the number of selected features at each locus ([more info](tiny-count.md#count-normalization)). The commandline option does not enable or disable the normalizations detailed above.
 
 ### Low DF Experiments
 DESeq2 requires that your experiment design has at least one degree of freedom. If your experiment doesn't include at least one sample group with more than one replicate, tiny-deseq.r will be skipped and DGE related plots will not be produced.

--- a/doc/Parameters.md
+++ b/doc/Parameters.md
@@ -114,8 +114,8 @@ Diagnostic information will include intermediate alignment files for each librar
 
 ### Full tiny-count Help String
 ```
-tiny-count (-pf FILE | --get-templates) [-o PREFIX] [-nh T/F] [-dc]
-           [-sv {Cython,HTSeq}] [-p] [-d]
+tiny-count (-pf FILE | --get-templates) [-o PREFIX] [-ng T/F] [-nf T/F]
+                  [-vs T/F] [-dc] [-sv {Cython,HTSeq}] [-p] [-d]
 
 tiny-count is a precision counting tool for hierarchical classification and
 quantification of small RNA-seq reads
@@ -139,9 +139,13 @@ Optional arguments:
                         occurrences of the substring {timestamp} will be
                         replaced with the current date and time. (default:
                         tiny-count_{timestamp})
-  -nh T/F, --normalize-by-hits T/F
-                        If T/true, normalize counts by (selected) overlapping
-                        feature counts. (default: T)
+  -ng T/F, --normalize-by-genomic-hits T/F
+                        Normalize counts by genomic hits. (default: T)
+  -nf T/F, --normalize-by-feature-hits T/F
+                        Normalize counts by feature hits. (default: T)
+  -vs T/F, --verify-stats T/F
+                        Verify that all reported stats are internally
+                        consistent. (default: T)
   -dc, --decollapse     Create a decollapsed copy of all SAM files listed in
                         your Samples Sheet. This option is ignored for non-
                         collapsed inputs. (default: False)

--- a/doc/Parameters.md
+++ b/doc/Parameters.md
@@ -70,12 +70,19 @@ Optional arguments:
 
 Copies the template configuration files required by tiny-count into the current directory. This argument can't be combined with `--paths-file`. All other arguments are ignored when provided, and once the templates have been copied tiny-count exits.
 
-### Normalize by Hits
-| Run Config Key             | Commandline Argument      |
-|----------------------------|---------------------------|
-| counter-normalize-by-hits: | `--normalize-by-hits T/F` |
+### Normalize by Genomic Hits
+| Run Config Key                     | Commandline Argument              |
+|------------------------------------|-----------------------------------|
+| counter_normalize_by_genomic_hits: | `--normalize-by-genomic-hits T/F` |
 
-By default, tiny-count will divide the number of counts associated with each sequence, twice, before they are assigned to a feature. Each unique sequence's count is determined by tiny-collapse (or a compatible collapsing utility) and is preserved through the alignment process. The original count is divided first by the number of loci that the sequence aligns to, and second by the number of features passing selection at each locus. Switching this option "off" disables the latter normalization step.
+By default, tiny-count will increment feature counts by a normalized amount to avoid overcounting. Each unique sequence's read count is determined by tiny-collapse (or a compatible collapsing utility) and is preserved through the alignment process. For sequences with multiple alignments, a portion of the sequence's original count is allocated to each of its alignments to be assigned to features that pass selection at the locus. This portion is the original count divided by the number of alignments, or _genomic hits_. By disabling this normalization step, each of the sequence's alignments will be allocated the full original read count rather than the normalized portion.
+
+### Normalize by Feature Hits
+| Run Config Key                     | Commandline Argument              |
+|------------------------------------|-----------------------------------|
+| counter_normalize_by_feature_hits: | `--normalize-by-feature-hits T/F` |
+
+By default, tiny-count will increment feature counts by a normalized amount to avoid overcounting. Each sequence alignment locus is allocated a portion of the sequence's original read count (depending on `counter_normalize_by_genomic_hits`), and once selection is complete the allocated count is divided by the number of selected features, or _feature hits_, at the alignment. The resulting value is added to the totals for each matching feature. By disabling this normalization step, each selected feature will receive the full amount allocated to the locus rather than the normalized portion.
 
 ### Decollapse
 | Run Config Key      | Commandline Argument   |

--- a/doc/tiny-count.md
+++ b/doc/tiny-count.md
@@ -138,7 +138,7 @@ Examples:
 >**Tip:** you may specify U and T bases in your rules. Uracil bases will be converted to thymine when your Features Sheet is loaded. N bases are also allowed.
 
 ## Count Normalization
-Small RNA reads passing selection will receive a normalized count increment. By default, read counts are normalized twice before being assigned to a feature. The second normalization step can be disabled in `run_config.yml` if desired. Counts for each small RNA sequence are divided: 
+Small RNA reads passing selection will receive a normalized count increment. By default, read counts are normalized twice before being assigned to a feature. Both normalization steps can be disabled in `run_config.yml` if desired. Counts for each small RNA sequence are divided: 
 1. By the number of loci it aligns to in the genome.
 2. By the number of _selected_ features for each of its alignments.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ EMAIL = 'ajtate@colostate.edu'
 AUTHOR = 'Kristen Brown, Alex Tate'
 PLATFORM = 'Unix'
 REQUIRES_PYTHON = '>=3.9.0'
-VERSION = '1.3.0'
+VERSION = '1.4.0'
 REQUIRED = []  # Required packages are installed via Conda's environment.yml
 
 

--- a/tests/testdata/config_files/run_config_template.yml
+++ b/tests/testdata/config_files/run_config_template.yml
@@ -225,9 +225,11 @@ shared_memory: False
 ##-- If True: show all parsed features in the counts csv, regardless of count/identity --##
 counter_all_features: False
 
-##-- If True: counts will be normalized by genomic hits AND selected feature count --##
-##-- If False: counts will only be normalized by genomic hits --##
-counter_normalize_by_hits: True
+##-- If True: counts are normalized by genomic hits (number of multi-alignments) --##
+counter_normalize_by_genomic_hits: True
+
+##-- If True: counts are normalized by feature hits (selected feature count per-locus) --##
+counter_normalize_by_feature_hits: True
 
 ##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
 counter_decollapse: False
@@ -326,7 +328,7 @@ dir_name_logs: logs
 #
 ###########################################################################################
 
-version: 1.3.0
+version: 1.4.0
 
 ######--------------------------- DERIVED FROM PATHS FILE ---------------------------######
 #

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -145,5 +145,10 @@ outputs:
     outputBinding:
       glob: $(inputs.out_prefix)_selection_diags.txt
 
+  stats_check:
+    type: File?
+    outputBinding:
+      glob: "*_stats_check.csv"
+
   console_output:
     type: stdout

--- a/tiny/cwl/tools/tiny-count.cwl
+++ b/tiny/cwl/tools/tiny-count.cwl
@@ -30,10 +30,15 @@ inputs:
 
   # Optional inputs
 
-  normalize_by_hits:
+  normalize_by_feature_hits:
     type: string?
     inputBinding:
-      prefix: --normalize-by-hits
+      prefix: --normalize-by-feature-hits
+
+  normalize_by_genomic_hits:
+    type: string?
+    inputBinding:
+      prefix: --normalize-by-genomic-hits
 
   decollapse:
     type: boolean?

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -87,7 +87,8 @@ inputs:
   counter_decollapse: boolean?
   counter_stepvector: string?
   counter_all_features: boolean?
-  counter_normalize_by_hits: boolean?
+  counter_normalize_by_feature_hits: boolean?
+  counter_normalize_by_genomic_hits: boolean?
 
   # tiny-deseq inputs
   run_deseq: boolean
@@ -214,8 +215,11 @@ steps:
       gff_files: gff_files
       out_prefix: run_name
       all_features: counter_all_features
-      normalize_by_hits:
-        source: counter_normalize_by_hits
+      normalize_by_feature_hits:
+        source: counter_normalize_by_feature_hits
+        valueFrom: $(String(self))  # convert boolean -> string
+      normalize_by_genomic_hits:
+        source: counter_normalize_by_genomic_hits
         valueFrom: $(String(self))  # convert boolean -> string
       decollapse: counter_decollapse
       stepvector: counter_stepvector

--- a/tiny/cwl/workflows/tinyrna_wf.cwl
+++ b/tiny/cwl/workflows/tinyrna_wf.cwl
@@ -229,7 +229,7 @@ steps:
       collapsed_fa: preprocessing/uniq_seqs
     out: [ feature_counts, rule_counts, norm_counts, mapped_nt_len_dist, assigned_nt_len_dist,
            alignment_stats, summary_stats, decollapsed_sams, alignment_tables,
-           assignment_diags, selection_diags ]
+           assignment_diags, selection_diags, stats_check ]
 
   tiny-deseq:
     run: ../tools/tiny-deseq.cwl
@@ -326,7 +326,7 @@ steps:
                   tiny-count/mapped_nt_len_dist, tiny-count/assigned_nt_len_dist,
                   tiny-count/alignment_stats, tiny-count/summary_stats, tiny-count/decollapsed_sams,
                   tiny-count/assignment_diags, tiny-count/selection_diags, tiny-count/alignment_tables,
-                  features_csv ]
+                  tiny-count/stats_check, features_csv ]
       dir_name: dir_name_tiny-count
     out: [ subdir ]
 

--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -896,8 +896,8 @@ class CSVReader(csv.DictReader):
             if 'mismatches' not in header_vals_lc:
                 compat_errors.append('\n'.join([
                     "It looks like you're using a Features Sheet from an earlier version of",
-                    'tinyRNA. An additional column, "Mismatches", is now expected. Please review'
-                    "the Stage 2 section in tiny-count's documentation for more info, then add"
+                    'tinyRNA. An additional column, "Mismatches", is now expected. Please review',
+                    "the Stage 2 section in tiny-count's documentation for more info, then add",
                     "the new column to your Features Sheet to avoid this error."
                 ]))
 

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -54,17 +54,17 @@ def get_args():
                                help='The output prefix to use for file names. All occurrences of the '
                                     'substring {timestamp} will be replaced with the current date and time.')
     optional_args.add_argument('-ng', '--normalize-by-genomic-hits', metavar='T/F', default='T',
-                               help='If T/true, normalize counts by genomic hits.')
+                               help='Normalize counts by genomic hits.')
     optional_args.add_argument('-nf', '--normalize-by-feature-hits', metavar='T/F', default='T',
-                               help='If T/true, normalize counts by feature hits.')
+                               help='Normalize counts by feature hits.')
+    optional_args.add_argument('-vs', '--verify-stats', metavar='T/F', default='T',
+                               help='Verify that all reported stats are internally consistent.')
     optional_args.add_argument('-dc', '--decollapse', action='store_true',
                                help='Create a decollapsed copy of all SAM files listed in your Samples Sheet. '
                                     'This option is ignored for non-collapsed inputs.')
     optional_args.add_argument('-sv', '--stepvector', choices=['Cython', 'HTSeq'], default='Cython',
                                help='Select which StepVector implementation is used to find '
                                     'features overlapping an interval.')
-    optional_args.add_argument('-vs', '--verify-stats', metavar='T/F', default='T',
-                                 help='If T/true, verify that all reported stats are internally consistent.')
     optional_args.add_argument('-a', '--all-features', action='store_true', help=argparse.SUPPRESS)
                                #help='Represent all features in output counts table, '
                                #     'even if they did not match in Stage 1 selection.')

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -55,8 +55,8 @@ def get_args():
                                     'substring {timestamp} will be replaced with the current date and time.')
     optional_args.add_argument('-ng', '--normalize-by-genomic-hits', metavar='T/F', default='T',
                                help='If T/true, normalize counts by genomic hits.')
-    optional_args.add_argument('-nh', '--normalize-by-feature-hits', metavar='T/F', default='T',
-                               help='If T/true, normalize counts by (selected) overlapping feature counts.')
+    optional_args.add_argument('-nf', '--normalize-by-feature-hits', metavar='T/F', default='T',
+                               help='If T/true, normalize counts by feature hits.')
     optional_args.add_argument('-dc', '--decollapse', action='store_true',
                                help='Create a decollapsed copy of all SAM files listed in your Samples Sheet. '
                                     'This option is ignored for non-collapsed inputs.')

--- a/tiny/rna/counter/counter.py
+++ b/tiny/rna/counter/counter.py
@@ -63,6 +63,8 @@ def get_args():
     optional_args.add_argument('-sv', '--stepvector', choices=['Cython', 'HTSeq'], default='Cython',
                                help='Select which StepVector implementation is used to find '
                                     'features overlapping an interval.')
+    optional_args.add_argument('-vs', '--verify-stats', metavar='T/F', default='T',
+                                 help='If T/true, verify that all reported stats are internally consistent.')
     optional_args.add_argument('-a', '--all-features', action='store_true', help=argparse.SUPPRESS)
                                #help='Represent all features in output counts table, '
                                #     'even if they did not match in Stage 1 selection.')
@@ -82,7 +84,7 @@ def get_args():
     else:
         args_dict = vars(args)
         args_dict['out_prefix'] = args.out_prefix.replace('{timestamp}', get_timestamp())
-        for tf in ('normalize_by_feature_hits', 'normalize_by_genomic_hits'):
+        for tf in ('normalize_by_feature_hits', 'normalize_by_genomic_hits', 'verify_stats'):
             args_dict[tf] = args_dict[tf].lower() in ['t', 'true']
         return ReadOnlyDict(args_dict)
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -385,12 +385,18 @@ class NtLenMatrices(MergedStat):
 class AlignmentStats(MergedStat):
     def __init__(self):
         self.alignment_stats_df = pd.DataFrame(index=LibraryStats.summary_categories)
+        self.finalized = False
 
     def add_library(self, other: LibraryStats):
+        assert not self.finalized, "Cannot add libraries after AlignmentStats object has been finalized."
         library, stats = other.library['Name'], other.library_stats
         self.alignment_stats_df[library] = self.alignment_stats_df.index.map(stats)
 
+    def finalize(self):
+        self.finalized = True  # Nothing else to do
+
     def write_output_logfile(self):
+        assert self.finalized, "AlignmentStats object must be finalized before writing output."
         self.df_to_csv(self.alignment_stats_df, "Alignment Statistics", self.prefix, 'alignment_stats')
 
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -27,7 +27,8 @@ class LibraryStats:
         self.library = {'Name': 'Unassigned', 'File': 'Unassigned', 'Norm': '1'}
         self.out_prefix = out_prefix
         self.diags = Diagnostics(out_prefix) if report_diags else None
-        self.norm = prefs.get('normalize_by_hits', True)
+        self.norm_gh = prefs.get('normalize_by_genomic_hits', True)
+        self.norm_fh = prefs.get('normalize_by_feature_hits', True)
 
         self.feat_counts = Counter()
         self.rule_counts = Counter()
@@ -44,7 +45,7 @@ class LibraryStats:
 
         bundle_read = aln_bundle[0]
         loci_counts = len(aln_bundle)
-        corr_counts = read_counts / loci_counts
+        corr_counts = read_counts / loci_counts if self.norm_gh else read_counts
         nt5, seqlen = bundle_read['nt5end'], bundle_read['Length']
 
         # Fill in 5p nt/length matrix
@@ -72,7 +73,7 @@ class LibraryStats:
         if asgn_count == 0:
             self.library_stats['Total Unassigned Reads'] += corr_count
         else:
-            fcorr_count = corr_count / asgn_count if self.norm else corr_count
+            fcorr_count = corr_count / asgn_count if self.norm_fh else corr_count
             bundle['assigned_reads'] += fcorr_count * asgn_count
             bundle['assigned_ftags'] |= assignments.keys()
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -46,7 +46,7 @@ class LibraryStats:
 
         bundle_read = aln_bundle[0]
         loci_counts = len(aln_bundle)
-        corr_counts = round(read_counts / loci_counts, 2) if self.norm_gh else read_counts
+        corr_counts = round(read_counts / loci_counts, 8) if self.norm_gh else read_counts
         nt5, seqlen = bundle_read['nt5end'], bundle_read['Length']
         self.library_stats['Mapped Reads Basis'] += read_counts
 
@@ -74,7 +74,7 @@ class LibraryStats:
         if asgn_count == 0:
             bundle['unassigned_reads'] += corr_count
         else:
-            fcorr_count = round(corr_count / asgn_count, 2) if self.norm_fh else corr_count
+            fcorr_count = round(corr_count / asgn_count, 8) if self.norm_fh else corr_count
             bundle['assigned_reads'] += fcorr_count * asgn_count
             bundle['assigned_ftags'] |= assignments.keys()
 
@@ -91,8 +91,8 @@ class LibraryStats:
         """Called at the conclusion of processing each multiple-alignment bundle"""
 
         assigned_feat_count = len({feat[0] for feat in bundle['assigned_ftags']})
-        unassigned_reads = round(bundle['unassigned_reads'], 2)
-        assigned_reads = round(bundle['assigned_reads'], 2)
+        unassigned_reads = round(bundle['unassigned_reads'], 8)
+        assigned_reads = round(bundle['assigned_reads'], 8)
 
         self.library_stats['Total Unassigned Reads'] += unassigned_reads
         bundle['nt5_mapped'][bundle['seq_length']] += assigned_reads + unassigned_reads
@@ -812,11 +812,10 @@ class StatisticsValidator:
                 MergedStat.add_warning(self.indent_vs(a_sum, s_df.loc['Assigned Reads', lib_name]))
 
     @staticmethod
-    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=1.0):
+    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=2.0):
         """Tolerate small differences in floating point numbers due to floating point error.
         The error tends to be greater for stats that are incremented many times by small
-        amounts. The default tolerance is definitely too generous for the error,
-        but seems conceptually appropriate for read counts."""
+        amounts. The default tolerance is likely too generous."""
 
         approx = abs(x - y) < tolerance
         if isinstance(approx, pd.Series):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -146,16 +146,26 @@ class MergedStat(ABC):
         return df.round(decimals=2).sort_index(axis=axis)
 
     @staticmethod
-    def df_to_csv(df: pd.DataFrame, idx_name: str, prefix: str, postfix: str = None, sort_axis="columns"):
+    def df_to_csv(df: pd.DataFrame, prefix: str, postfix: str = None, sort_axis="columns"):
+        """Rounds counts, optionally sorts , and writes the dataframe
+        to CSV with the appropriate index label and filename.
+
+        Args:
+            df: The dataframe to write to CSV
+            prefix: The output filename prefix (required)
+            postfix: The optional filename postfix. If not provided, a postfix is created from
+                the index name, which will be split on space, joined on "_", and made lowercase.
+            sort_axis: The axis to sort. Default: columns. If None, neither axis is sorted.
+        """
+
         if postfix is None:
-            postfix = '_'.join(map(str.lower, idx_name.split(' ')))
+            postfix = '_'.join(map(str.lower, df.index.name.split(' ')))
 
         if sort_axis is not None:
             out_df = MergedStat.sort_cols_and_round(df, axis=sort_axis)
         else:
             out_df = df.round(decimals=2)
 
-        out_df.index.name = idx_name
         file_name = make_filename([prefix, postfix])
         out_df.to_csv(file_name)
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -421,7 +421,8 @@ class NtLenMatrices(MergedStat):
         if self.norm_gh ^ self.norm_fh:
             self.df_to_csv(mapped, self.prefix, postfix, sort_axis=None)
         else:
-            self.df_to_csv(mapped.astype('int64'), self.prefix, postfix, sort_axis=None)
+            mapped_whole_numbers = mapped.round(decimals=2).astype('int64')
+            self.df_to_csv(mapped_whole_numbers, self.prefix, postfix, sort_axis=None)
 
     def _write_assigned(self, assigned: pd.DataFrame, lib_name: str):
         """Writes the assigned matrix to a file (no further work required)."""
@@ -822,10 +823,10 @@ class StatisticsValidator:
                 MergedStat.add_warning(self.indent_vs(a_sum, s_df.loc['Assigned Reads', lib_name]))
 
     @staticmethod
-    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=0.01):
+    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=1.0):
         """Tolerate small differences in floating point numbers due to floating point error.
         The error tends to be greater for stats that are incremented many times by small
-        amounts. The default tolerance is likely too generous."""
+        amounts. The default tolerance, while conceptually appropriate, is excessive."""
 
         approx = abs(x - y) < tolerance
         if isinstance(approx, pd.Series):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -141,14 +141,8 @@ class MergedStat(ABC):
         MergedStatsManager.warnings.append(msg)
 
     @staticmethod
-    def sort_cols_and_round(df: pd.DataFrame, axis="columns") -> pd.DataFrame:
-        """Convenience function to sort columns by title and round all values to 2 decimal places"""
-        return df.round(decimals=2).sort_index(axis=axis)
-
-    @staticmethod
-    def df_to_csv(df: pd.DataFrame, prefix: str, postfix: str = None, sort_axis="columns"):
-        """Rounds counts, optionally sorts , and writes the dataframe
-        to CSV with the appropriate index label and filename.
+    def df_to_csv(df: pd.DataFrame, prefix: str, postfix: str = None, sort_axis: Optional[str] = "columns"):
+        """Rounds counts, optionally sorts an axis, and writes the dataframe to CSV with the appropriate filename.
 
         Args:
             df: The dataframe to write to CSV
@@ -162,7 +156,7 @@ class MergedStat(ABC):
             postfix = '_'.join(map(str.lower, df.index.name.split(' ')))
 
         if sort_axis is not None:
-            out_df = MergedStat.sort_cols_and_round(df, axis=sort_axis)
+            out_df = df.round(decimals=2).sort_index(axis=sort_axis)
         else:
             out_df = df.round(decimals=2)
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -46,7 +46,7 @@ class LibraryStats:
 
         bundle_read = aln_bundle[0]
         loci_counts = len(aln_bundle)
-        corr_counts = round(read_counts / loci_counts, 8) if self.norm_gh else read_counts
+        corr_counts = read_counts / loci_counts if self.norm_gh else read_counts
         nt5, seqlen = bundle_read['nt5end'], bundle_read['Length']
         self.library_stats['Mapped Reads Basis'] += read_counts
 
@@ -74,7 +74,7 @@ class LibraryStats:
         if asgn_count == 0:
             bundle['unassigned_reads'] += corr_count
         else:
-            fcorr_count = round(corr_count / asgn_count, 8) if self.norm_fh else corr_count
+            fcorr_count = corr_count / asgn_count if self.norm_fh else corr_count
             bundle['assigned_reads'] += fcorr_count * asgn_count
             bundle['assigned_ftags'] |= assignments.keys()
 
@@ -91,8 +91,8 @@ class LibraryStats:
         """Called at the conclusion of processing each multiple-alignment bundle"""
 
         assigned_feat_count = len({feat[0] for feat in bundle['assigned_ftags']})
-        unassigned_reads = round(bundle['unassigned_reads'], 8)
-        assigned_reads = round(bundle['assigned_reads'], 8)
+        unassigned_reads = bundle['unassigned_reads']
+        assigned_reads = bundle['assigned_reads']
 
         self.library_stats['Total Unassigned Reads'] += unassigned_reads
         bundle['nt5_mapped'][bundle['seq_length']] += assigned_reads + unassigned_reads

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -589,8 +589,7 @@ class Diagnostics:
     complement = bytes.maketrans(b'ACGTacgt', b'TGCAtgca')
     map_strand = {True: '+', False: '-', None: '.'}
 
-    def __init__(self, out_prefix: str):
-        self.prefix = out_prefix
+    def __init__(self):
         self.assignment_diags = {stat: 0 for stat in Diagnostics.summary_categories}
         self.selection_diags = defaultdict(Counter)
         self.alignments = []
@@ -648,7 +647,7 @@ class MergedDiags(MergedStat):
         # self.selection_diags[other_lib] = other.diags.selection_diags  Not currently collected
         self.assignment_diags[other_lib] = self.assignment_diags.index.map(other.diags.assignment_diags)
 
-    def finalize(self): pass
+    def finalize(self): pass  # Nothing to do
 
     def write_output_logfile(self):
         self.write_assignment_diags()

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -114,10 +114,13 @@ class MergedStat(ABC):
     prefix = None
 
     @abstractmethod
-    def add_library(self, other: LibraryStats): pass
+    def add_library(self, other: LibraryStats): ...
 
     @abstractmethod
-    def write_output_logfile(self): pass
+    def finalize(self): ...
+
+    @abstractmethod
+    def write_output_logfile(self): ...
 
     @staticmethod
     def add_warning(msg):
@@ -160,6 +163,15 @@ class MergedStatsManager:
             self.merged_stats.append(MergedDiags())
 
     def write_report_files(self) -> None:
+        try:
+            for in_process in self.merged_stats:
+                in_process.finalize()
+
+            # Validate stats now that all libraries have been processed
+            StatisticsValidator(self.merged_stats).validate()
+        finally:
+            self.print_warnings()
+
         for output_stat in self.merged_stats:
             output_stat.write_output_logfile()
         self.print_warnings()

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -120,10 +120,21 @@ class MergedStat(ABC):
     def add_library(self, other: LibraryStats): ...
 
     @abstractmethod
-    def finalize(self): ...  # Called before validating stats
+    def finalize(self):
+        """Called once all libraries have been added to the MergedStatsManager.
+        The implementation of this method should perform any preparation steps required for
+        stats validation, such as building dataframes or sorting columns so the appropriate
+        comparisons can be made, but it should not perform any operations that reduce decimal
+        precision, such as rounding or conversion to int. Validation depends on this precision
+        for internal consistency checks. Rounding should instead be done in write_output_logfile()"""
+        ...
 
     @abstractmethod
-    def write_output_logfile(self): ...
+    def write_output_logfile(self):
+        """Called once all stats classes have been validated.
+        The implementation of this method should round counts to the appropriate decimal
+        precision or convert float values to int if necessary, then write output CSV files."""
+        ...
 
     @staticmethod
     def add_warning(msg):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -437,7 +437,8 @@ class NtLenMatrices(MergedStat):
 
 class AlignmentStats(MergedStat):
     def __init__(self):
-        self.alignment_stats_df = pd.DataFrame(index=LibraryStats.summary_categories)
+        self.alignment_stats_df = (pd.DataFrame(index=LibraryStats.summary_categories)
+                                   .rename_axis("Alignment Statistics"))
         self.finalized = False
 
     def add_library(self, other: LibraryStats):
@@ -447,12 +448,12 @@ class AlignmentStats(MergedStat):
 
     def finalize(self):
         self.alignment_stats_df.drop(index="Mapped Reads Basis", inplace=True)  # Handled by SummaryStats
-        self.alignment_stats_df = self.sort_cols_and_round(self.alignment_stats_df)
+        self.alignment_stats_df.sort_index(axis="columns", inplace=True)
         self.finalized = True
 
     def write_output_logfile(self):
         assert self.finalized, "AlignmentStats object must be finalized before writing output."
-        self.df_to_csv(self.alignment_stats_df, "Alignment Statistics", self.prefix, 'alignment_stats')
+        self.df_to_csv(self.alignment_stats_df, self.prefix, 'alignment_stats')
 
 
 class SummaryStats(MergedStat):

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -89,21 +89,19 @@ class LibraryStats:
         """Called at the conclusion of processing each multiple-alignment bundle"""
 
         assigned_feat_count = len({feat[0] for feat in bundle['assigned_ftags']})
+        unassigned_reads = round(bundle['unassigned_reads'], 2)
+        assigned_reads = round(bundle['assigned_reads'], 2)
+
+        self.library_stats['Total Unassigned Reads'] += unassigned_reads
+        bundle['nt5_mapped'][bundle['seq_length']] += assigned_reads + unassigned_reads
 
         if assigned_feat_count == 0:
             self.library_stats['Total Unassigned Sequences'] += 1
         else:
             self.library_stats['Total Assigned Sequences'] += 1
-            assigned_reads = round(bundle['assigned_reads'], 2)
-            unassigned_reads = round(bundle['unassigned_reads'], 2)
-
-            self.library_stats['Total Unassigned Reads'] += unassigned_reads
             self.library_stats['Total Assigned Reads'] += assigned_reads
             self.library_stats[bundle['mapping_stat']] += assigned_reads
-
-            seqlen = bundle['seq_length']
-            bundle['nt5_assigned'][seqlen] += assigned_reads
-            bundle['nt5_mapped'][seqlen] += assigned_reads + unassigned_reads
+            bundle['nt5_assigned'][bundle['seq_length']] += assigned_reads
 
             if assigned_feat_count == 1:
                 self.library_stats['Reads Assigned to Single Feature'] += assigned_reads

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -673,7 +673,7 @@ class Diagnostics:
 
 class MergedDiags(MergedStat):
     def __init__(self):
-        self.assignment_diags = pd.DataFrame(index=Diagnostics.summary_categories)
+        self.assignment_diags = pd.DataFrame(index=Diagnostics.summary_categories).rename_axis("Assignment Diags")
         self.selection_diags = {}
         self.alignment_tables = {}
 
@@ -691,7 +691,7 @@ class MergedDiags(MergedStat):
         self.write_alignment_tables()
 
     def write_assignment_diags(self):
-        self.df_to_csv(self.assignment_diags, "Assignment Diags", self.prefix, "assignment_diags")
+        self.df_to_csv(self.assignment_diags, self.prefix)
 
     def write_alignment_tables(self):
         header = Diagnostics.alignment_columns

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -462,7 +462,7 @@ class SummaryStats(MergedStat):
     counted_categories      = ["Mapped Sequences", "Normalized Mapped Reads", "Mapped Reads", "Assigned Reads"]
     summary_categories      = conditional_categories + counted_categories
 
-    pipeline_stats_df = pd.DataFrame(index=summary_categories)
+    pipeline_stats_df = pd.DataFrame(index=summary_categories).rename_axis("Summary Statistics")
 
     def __init__(self, prefs):
         self.norm_gh = prefs.get('normalize_by_genomic_hits', True)
@@ -528,7 +528,7 @@ class SummaryStats(MergedStat):
         # Only display conditional categories if they were collected for at least one library
         empty_rows = self.pipeline_stats_df.loc[self.conditional_categories].isna().all(axis='columns')
         self.pipeline_stats_df.drop(empty_rows.index[empty_rows], inplace=True)
-        self.pipeline_stats_df = self.sort_cols_and_round(self.pipeline_stats_df)
+        self.pipeline_stats_df.sort_index(axis="columns", inplace=True)
         self.finalized = True
 
     def write_output_logfile(self):
@@ -544,7 +544,7 @@ class SummaryStats(MergedStat):
             differentiate = {'Mapped Reads': "Non-normalized Mapped Reads"}
             out_df = self.pipeline_stats_df.rename(index=differentiate)
 
-        self.df_to_csv(out_df, "Summary Statistics", self.prefix, "summary_stats")
+        self.df_to_csv(out_df, self.prefix, "summary_stats")
 
     def library_has_collapser_outputs(self, other: LibraryStats) -> bool:
         # Collapser outputs may have been gzipped. Accept either filename.

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -26,7 +26,7 @@ class LibraryStats:
 
     def __init__(self, **prefs):
         self.library = {'Name': 'Unassigned', 'File': 'Unassigned', 'Norm': '1'}
-        self.diags = Diagnostics(**prefs) if prefs.get('report_diags') else None
+        self.diags = Diagnostics() if prefs.get('report_diags') else None
         self.norm_gh = prefs.get('normalize_by_genomic_hits', True)
         self.norm_fh = prefs.get('normalize_by_feature_hits', True)
 
@@ -790,7 +790,7 @@ class StatisticsValidator:
                 MergedStat.add_warning(self.indent_vs(a_sum, s_df.loc['Assigned Reads', lib_name]))
 
     @staticmethod
-    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=0.01):
+    def approx_equal(x: Union[pd.Series, int], y: Union[pd.Series, int], tolerance=1.0):
         """Tolerate small differences in floating point numbers due to floating point error.
         The error tends to be greater for stats that are incremented many times by small
         amounts. The default tolerance is definitely too generous for the error,

--- a/tiny/rna/plotter.py
+++ b/tiny/rna/plotter.py
@@ -256,6 +256,13 @@ def get_proportions_df(counts_df: pd.DataFrame, mapped_totals: pd.Series, un: st
 
 def load_mapped_reads(summary_stats_file: str) -> pd.Series:
     """Produces a Series of mapped reads per library for calculating proportions in class charts.
+    If normalization by genomic hits and/or feature hits was disabled during the counting run,
+    then the normal "Mapped Reads" calculation will be an inflated count, so in summary stats
+    it is differentiated as:
+        "Normalized Mapped Reads" and "Non-normalized Mapped Reads"
+
+    For proper calculation of proportions with non-normalized counts, the
+    "Non-normalized Mapped Reads" stat has to be used.
 
     Args:
         summary_stats_file: the summary stats csv produced by tiny-count
@@ -263,7 +270,11 @@ def load_mapped_reads(summary_stats_file: str) -> pd.Series:
     Returns: a Series containing mapped reads per sample
     """
 
-    return pd.read_csv(summary_stats_file, index_col=0).loc["Mapped Reads",:]
+    stats = pd.read_csv(summary_stats_file, index_col=0)
+    if "Mapped Reads" in stats.index:
+        return stats.loc['Mapped Reads']
+    else:
+        return stats.loc['Non-normalized Mapped Reads']
 
 
 def get_sample_rep_dict(df: pd.DataFrame) -> dict:

--- a/tiny/templates/compatibility/run_config_compatibility.yml
+++ b/tiny/templates/compatibility/run_config_compatibility.yml
@@ -6,6 +6,12 @@
 #  - Renames are evaluated before additions; preceding_key should use the new name if version renames it
 
 
+1.4.0:
+  rename:
+    - counter_normalize_by_hits: counter_normalize_by_feature_hits
+  add:
+    - preceding_key: counter_normalize_by_feature_hits
+      counter_normalize_by_genomic_hits: True
 1.3.0:
   remove: []
   rename:

--- a/tiny/templates/run_config_template.yml
+++ b/tiny/templates/run_config_template.yml
@@ -225,9 +225,11 @@ shared_memory: False
 ##-- If True: show all parsed features in the counts csv, regardless of count/identity --##
 counter_all_features: False
 
-##-- If True: counts will be normalized by genomic hits AND selected feature count --##
-##-- If False: counts will only be normalized by genomic hits --##
-counter_normalize_by_hits: True
+##-- If True: counts are normalized by genomic hits (number of multi-alignments) --##
+counter_normalize_by_genomic_hits: True
+
+##-- If True: counts are normalized by feature hits (selected feature count per-locus) --##
+counter_normalize_by_feature_hits: True
 
 ##-- If True: a decollapsed copy of each SAM file will be produced (useful for IGV) --##
 counter_decollapse: False
@@ -326,7 +328,7 @@ dir_name_logs: logs
 #
 ###########################################################################################
 
-version: 1.3.0
+version: 1.4.0
 
 ######--------------------------- DERIVED FROM PATHS FILE ---------------------------######
 #


### PR DESCRIPTION
The two normalization-by-hits options, by genomic hits and feature hits, can now be disabled both independently and in tandem. When either normalization step is disabled, two new stats are reported in summary stats in place of Mapped Reads:
- **Non-normalized Mapped Reads**: the sum of assigned and unassigned reads according to the normalization config
- **Normalized Mapped Reads**: the true read count

tiny-plot automatically uses the appropriate stat for calculating proportions in rule_charts and class_charts.

### Internal Consistency Checks for Reported Stats
The counts reported in all output stats files are now thoroughly checked for internal consistency. Discrepancies are reported to console with a clear description rather than being treated as an error. If alignment stats and summary stats have internal disagreement, a checksum table is produced as a CSV file for further diagnosis. Care has been taken to ensure that the consistency checker can fail gracefully if any unforeseen exceptions are raised. This prevents counting outputs from being lost at the fault of the consistency checker. Consistency is checked after every run and is typically a very swift process (usually a fraction of a second). Nonetheless, a command line option has been added to tiny-count to allow this step to be turned off if needed. The following checks are performed for each library:
- Internal consistency for all assigned/unassigned read/sequence counts in alignment stats and summary stats
- Non-normalized Mapped Reads >= Normalized Mapped Reads
- Reported count totals in feature counts == reported count totals in rule counts
- Reported count totals in rule counts == assigned read count in summary stats (same for feature counts by transitive property)
- Reported count totals in rule counts <= its mapped reads row
- Reported counts per classifier have equal sums in feature counts and rule counts
- Total reads in mapped nt/len matrices == mapped reads in summary stats
- Total reads in assigned nt/len matrices == assigned reads in summary stats

### Codebase Improvements
MergedStats classes have been mildly refactored to ensure that stats are complete and final before being validated and written to output files.

Closes #295