### PR TITLE
Bugfix: scatter_by_dge_class plots are properly aligned

### DIFF
--- a/tiny/rna/plotterlib.py
+++ b/tiny/rna/plotterlib.py
@@ -719,7 +719,7 @@ class LenDistCache(CacheBase):
 
 class ScatterCache(CacheBase):
     def __init__(self):
-        self.fig, self.ax = plt.subplots(figsize=(8, 8), tight_layout=False)
+        self.fig, self.ax = plt.subplots(figsize=(8, 8), layout="none")
         self.ax.set_aspect('equal')
 
     def get(self) -> Tuple[plt.Figure, plt.Axes]:


### PR DESCRIPTION
This PR fixes the alignment issue in scatter_by_dge_class which caused the plot legend to be clipped

Closes #313 