### PR TITLE
pipeline: correct handling of optional run_directory suffix in Paths File

### DIFF
--- a/tiny/rna/configuration.py
+++ b/tiny/rna/configuration.py
@@ -297,7 +297,7 @@ class Configuration(ConfigBase):
         # Prefix Run Directory basename while preserving subdirectory structure
         rd_head, rd_tail = os.path.split(self['run_directory'].rstrip(os.sep))
         basename = '_'.join(x for x in [self['run_name'], rd_tail] if x)
-        self['run_directory'] = self.joinpath(rd_head, basename)
+        self['run_directory'] = self.joinpath(rd_head or os.getcwd(), basename)
 
         self.templates = resource_filename('tiny', 'templates/')
 


### PR DESCRIPTION
An empty `run_directory` value in the Paths File no longer produces processed Run Configs with incomplete relative paths.

Closes #320 