### PR TITLE
tiny-count: minor change to internal consistency checks

### DIFF
--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -767,7 +767,7 @@ class StatisticsValidator:
             MergedStat.add_warning("Alignment stats and summary stats disagree on the number of assigned reads.")
             MergedStat.add_warning(self.indent_table(a_df.loc[TAR], s_df.loc[AR], index=("Alignment Stats", "Summary Stats")))
 
-        if s_df.loc[NMR].gt(s_df.loc[MR]).any():
+        if not self.approx_equal(s_df.loc[NMR], s_df.loc[MR]) and s_df.loc[NMR].gt(s_df.loc[MR]).any():
             MergedStat.add_warning("Summary stats reports normalized mapped reads > non-normalized mapped reads.")
             MergedStat.add_warning(self.indent_table(s_df.loc[NMR], s_df.loc(MR), index=("Normalized", "Non-normalized")))
 

--- a/tiny/rna/counter/statistics.py
+++ b/tiny/rna/counter/statistics.py
@@ -769,7 +769,7 @@ class StatisticsValidator:
 
         if not self.approx_equal(s_df.loc[NMR], s_df.loc[MR]) and s_df.loc[NMR].gt(s_df.loc[MR]).any():
             MergedStat.add_warning("Summary stats reports normalized mapped reads > non-normalized mapped reads.")
-            MergedStat.add_warning(self.indent_table(s_df.loc[NMR], s_df.loc(MR), index=("Normalized", "Non-normalized")))
+            MergedStat.add_warning(self.indent_table(s_df.loc[NMR], s_df.loc[MR], index=("Normalized", "Non-normalized")))
 
         if not self.approx_equal(res.loc["Sum"].sum(), 0):
             outfile_name = "stats_check"


### PR DESCRIPTION
- Added tolerance for floating point error when testing `normalized mapped reads ≤ non-normalized mapped reads`
- Syntax error correction when handling the above warning case