### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,36 +8,37 @@ assignees: ''
 ---
 
 --- Delete this text ---
-If you would like to report a bug, please fill out the template below. Before submitting your issue, make sure it is not repeated in [open issues](https://github.com/MontgomeryLab/tinyrna/issues). 
 
-For enhancements, please make sure we are already not working on this under [projects](https://github.com/MontgomeryLab/tinyrna/projects). Instead of filling out the template, just describe the feature you think would be useful to have. Any additional info that provides context or how you envision it implemented is also helpful. 
+If you would like to report a bug, please make sure there isn't an existing issue for it in [open issues](https://github.com/MontgomeryLab/tinyrna/issues), then fill out the template below.
+
+For enhancements, you can skip the template and just describe the feature you think would be useful to have.
+
 --- Delete this text ---
 
 
 ## Basic description of the error
-Please describe what you believe should have happened and what actually happened in simple terms. If you think you have an idea of what caused the error, that is also welcome here. 
+Please describe what you believe should have happened and what actually happened. If you think you have an idea of what caused the error, that is also welcome here. 
 
 ## Environment
-**Operating System:** Mac OS Mojave
-**tinyrna version:** v0.1
-**Additional comments:** 
+Please replace the examples below with your own environment info.
 
-## Reproducible example
+- **Operating system and version:** macOS Sonoma
+- **tinyRNA version:** 1.5
+- **Additional comments:** 
+
+## Relevant Commands
 
 ```
 Please replace this text with the commands you used to produce the error
 ```
 
-If you are using data files, we may need more information on the file (you may send it via email or attach it here) or if you give a snippet of the file we can test it. We need to be able to reproduce the error to know when we've fixed it. If you can use simple generated data that is similar to yours & still get the bug, that would be the best option. Ideally, attach an MCVE to the report that we can run here. 
+## Diagnostic Info
 
-## Input configuration 
+### 1. Terminal Output
+If the terminal output from the failing command is still available, please export it to a text file and attach it or paste it here. On macOS, one option is to use the terminal menu to select `Shell > Export Text As...` and save the output to a file, but this will save *everything* in the scrollback, so you may need to edit the file to remove sensitive/irrelevant information.
 
-```
-Please attach as a file or paste in this block your configuration file (the dated one)
-```
+### 2. Configuration Files
+If the failing command is `tiny` or `tiny-count`, please find the /config subdirectory in the Run Directory that was produced by the failing command, compress or archive it, and attach it here. On macOS, one option is to right-click the directory in Finder and select `Compress "config"`, then attach the resulting .zip file here.
 
-## Error message and traceback
-
-```
-Please replace this text & copy the output of the code when it errors 
-```
+### 3. Log Files
+If the failing command is `tiny`, please find the /logs subdirectory in the Run Directory that was produced by the failing command, compress or archive it, and attach it here.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ And this feature matched a rule in your Features Sheet defining _Classify as..._
 
 | Feature ID | Classifier | Feature Name     | Group1_rep_1 | Group1_rep_2 | ... |
 |------------|------------|------------------|--------------|--------------|-----|
-| 406904     | miRNA      | mir-1, hsa-miR-1 | 1234         | 999          | ... |
+| 406904     | miRNA      | hsa-miR-1, mir-1 | 1234         | 999          | ... |
 
 #### Normalized Counts
 If your Samples Sheet has settings for Normalization, an additional copy of the Feature Counts table is produced with the specified per-library normalizations applied. Note that these normalizations are [unrelated to normalization by genomic/feature hits](doc/Configuration.md#applying-custom-normalization).


### PR DESCRIPTION
This PR cleans up the issue template and updates the instructions for attaching diagnostic information.

It also provides a minor correction to the ordering of alias values in the tiny-count output feature_counts.csv. If a feature has multiple aliases associated with it, the values will be sorted in the Feature Name column. The order of the values does not reflect their original order in annotations, nor does it reflect the order in which alias keys were defined in the Paths File.