### PR TITLE
setup.sh: Mamba support, general improvements

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -31,7 +31,7 @@ Replace `3.XX` with the target Python version. This command will produce a new e
 
 ### 2. Create Platform-Specific Lockfiles
 ```shell
-python3 env.py update-locks --env-file environment_3.XX.yml
+python3 env.py rebuild-locks --env-file environment_3.XX.yml
 ```
 
 Replace `environment_3.XX.yml` with the name of the environment file you created in step 1. This command will rebuild the dependency tree in both lockfiles (linux and osx) according to the new environment file.

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 #   ./setup.sh preferred_name
 
 env_name=${1:-tinyrna}
-miniconda_version="23.3.1-0"
+miniconda_version="25.1.1-2"
 cwd="$(dirname "$0")"
 export ts=$(date +%Y-%m-%d_%H-%M-%S) && readonly ts
 
@@ -358,14 +358,19 @@ if ! pip install "$cwd" > "$logfile" 2>&1; then
 fi
 success "tinyRNA codebase installed"
 
+
+######---------------------------------- FINALIZE -----------------------------------######
+
+
 success "Setup complete"
 if [[ $miniconda_installed -eq 1 ]]; then
-  status "First, run this one-time command to finalize the Miniconda installation:"
   echo
-  echo "  source ~/${shell}.rc"
+  echo "First, run this one-time command to finalize the Miniconda installation:"
   echo
+  echo "  source $shellrc"
 fi
-status "To activate the environment, run:"
 echo
-echo "  conda activate $env_name"
+echo "To activate the environment, run:"
+echo
+echo "  $CONDA activate $env_name"
 echo

--- a/setup.sh
+++ b/setup.sh
@@ -129,7 +129,7 @@ function verify_miniconda_checksum() {
   local installer_file; local repo_index; local installer_hash; local expected_hash;
 
   installer_file="$1"
-  if ! installer_hash=$(shasum -a 256 "$installer_file" | cut -f 1 -d ' '); then
+  if ! installer_hash=$(set -o pipefail && shasum -a 256 "$installer_file" | cut -f 1 -d ' '); then
     fail "Failed to get checksum for Miniconda installer"
     return 1
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -125,7 +125,7 @@ function download_and_install_miniconda() {
   fi
 }
 
-function verify_conda_checksum() {
+function verify_miniconda_checksum() {
   local installer_file; local repo_index; local installer_hash; local expected_hash;
 
   installer_file="$1"
@@ -246,7 +246,7 @@ function setup_macOS_command_line_tools() {
 
 
 if [[ $CONDA_DEFAULT_ENV == "$env_name" ]]; then
-    fail "You must deactivate the $env_name environment before running this script."
+    fail "You must deactivate the $env_name environment before running this script"
     exit 1
 fi
 
@@ -321,8 +321,8 @@ fi
 
 if get_env_list | $GREP -q "^${env_name}\t/"; then
   echo
-  echo "The Conda environment \"$env_name\" already exists."
-  echo "It must be removed and recreated."
+  echo "The Conda environment \"$env_name\" already exists"
+  echo "It must be removed and recreated"
   echo
   read -p "Would you like to proceed? [y/n]: " -n 1 -r
   echo

--- a/setup.sh
+++ b/setup.sh
@@ -7,29 +7,41 @@
 env_name=${1:-tinyrna}
 miniconda_version="23.3.1-0"
 cwd="$(dirname "$0")"
+export ts=$(date +%Y-%m-%d_%H-%M-%S) && readonly ts
 
-# This is the default Python version that will be used by Miniconda (if Miniconda requires installation).
+# This is the default Python version that will be used by Miniconda (if installation of Miniconda is required).
 # Note that this isn't the same as the tinyRNA environment's Python version.
 # The tinyRNA environment's Python version is instead specified in the platform lockfile.
 miniconda_python_version="310"
 
+
+######------------------------------ HELPER FUNCTIONS -------------------------------######
+
+
 function success() {
-  check="✓"
-  green_on="\033[1;32m"
-  green_off="\033[0m"
+  local check="✓"
+  local green_on="\033[1;32m"
+  local green_off="\033[0m"
   printf "${green_on}${check} %s${green_off}\n" "$*"
 }
 
 function status() {
-  blue_on="\033[1;34m"
-  blue_off="\033[0m"
+  local blue_on="\033[1;34m"
+  local blue_off="\033[0m"
   printf "${blue_on}%s${blue_off}\n" "$*"
 }
 
+function warn() {
+  local exclaim="⚠"
+  local yellow_on="\033[1;33m"
+  local yellow_off="\033[0m"
+  printf "${yellow_on}${exclaim} %s${yellow_off}\n" "$*"
+}
+
 function fail() {
-  nope="⃠"
-  red_on="\033[1;31m"
-  red_off="\033[0m"
+  local nope="⃠"
+  local red_on="\033[1;31m"
+  local red_off="\033[0m"
   printf "${red_on}${nope} %s${red_off}\n" "$*"
 }
 
@@ -222,7 +234,7 @@ function setup_macOS_command_line_tools() {
       success "Command line tools setup complete"
     else
       fail "Command line tools installation failed"
-      exit 1
+      stop
     fi
   else
     success "Xcode command line tools are already installed"
@@ -342,11 +354,12 @@ echo '{"env_vars": {"PYTHONNOUSERSITE": "1"}}' > "$CONDA_PREFIX/conda-meta/state
 
 ######---------------------------- tinyRNA INSTALLATION -----------------------------######
 
-# Install the tinyRNA codebase
+
 status "Installing tinyRNA codebase via pip..."
-if ! pip install "$cwd" > "pip_install.log" 2>&1; then
-  fail "Failed to install tinyRNA codebase"
-  echo "Check the pip_install.log file for more information."
+logfile="pip_install_${ts}.log"
+
+if ! pip install "$cwd" > "$logfile" 2>&1; then
+  fail "Failed to install tinyRNA codebase (see ${logfile})"
   exit 1
 fi
 success "tinyRNA codebase installed"


### PR DESCRIPTION
This PR adds support for utilizing host `mamba` and `micromamba` installations for environment setup. If `conda` is also installed on the host, it will be used instead.

## New Behavior
- Log files are timestamped to avoid overwriting diagnostic outputs
- If an existing environment has to be removed, the output from this operation is written to env_remove.log
- Output from environment installation is now hidden from the console. It is still written to env_install.log.
- The installer now differentiates between the host's configured default shell and the shell that's currently running the script.  If they aren't the same, a warning is printed and installation proceeds for the CURRENT shell, not the default shell. Rationale: if a user's preferred shell (assumed to be the default shell) isn't supported, they will use bash/zsh instead for the installation.
- Miniconda version updated to latest (25.1.1-2)

## Bug Fixes
- The URL for Miniconda installer checksums is no longer valid. It has been corrected to https://repo.anaconda.com/miniconda/. The file hashes at this endpoint are delivered as an HTML table which setup.sh attempts to parse with awk rather than requiring 3rd party utilities for (reliably) parsing HTML. This approach is sensitive to changes in HTML structure, so as a fallback we search the entire table for a matching hash.
- On macOS terminal sessions run as "login" shells so if the user's default shell is Bash, it will source [~/.bash_profile instead of ~/.bashrc](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html) at startup. The installer has been corrected to query and run the Conda init block from ~./bash_profile on macOS when Bash is the default shell. On Linux, Bash is invoked as a "non-login" shell so ~/.bashrc continues to be used.
- Startup files (.zshrc, .bashrc, etc.) are likely to contain other code that's unrelated to Conda init. If Miniconda installation is required, our installer script has to extract and execute the Conda init block from one of these startup files in order to finalize the installation. For this reason, the installer is now more precise in extracting the init block so that unrelated code isn't executed.
- Helper functions now properly terminate the installation script if they encounter an irrecoverable error.